### PR TITLE
Update 'check-headers.sh' to include LFX

### DIFF
--- a/check-headers.sh
+++ b/check-headers.sh
@@ -34,7 +34,7 @@ files=()
 while IFS='' read -r line; do files+=("$line"); done < <(git ls-files -c "${filetypes[@]}" | grep -E -v "${exclude_pattern}")
 
 # This is the copyright line to look for - adjust as necessary
-copyright_line="Copyright The Linux Foundation"
+copyright_line="Copyright The Linux Foundation and each contributor to LFX"
 
 # Flag to indicate if we were successful or not
 missing_license_header=0


### PR DESCRIPTION
Updates the 'check-header.sh' script to include the line "and each
contributor to LFX"

Signed-off-by: Trevor Bramwell <tbramwell@linuxfoundation.org>
