### PR TITLE
[LFXV2-15] Create Heimdall Signer PEM Cert on Helm Install

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -6,6 +6,7 @@
     "authelia",
     "dadrus",
     "dbname",
+    "finalizer",
     "gelf",
     "jetstream",
     "jouve",

--- a/charts/lfx-platform/templates/heimdall/heimdall-signer-cert.yaml
+++ b/charts/lfx-platform/templates/heimdall/heimdall-signer-cert.yaml
@@ -21,6 +21,6 @@ metadata:
     helm.sh/hook: pre-install
     helm.sh/hook-weight: "0"
     helm.sh/hook-delete-policy: before-hook-creation
-data: 
+data:
   "signer.pem": "{{ $heimdallCert | b64enc }}"
 {{- end }}

--- a/charts/lfx-platform/templates/heimdall/heimdall-signer-cert.yaml
+++ b/charts/lfx-platform/templates/heimdall/heimdall-signer-cert.yaml
@@ -1,0 +1,26 @@
+# Copyright The Linux Foundation and each contributor to LFX.
+# SPDX-License-Identifier: MIT
+---
+{{ if .Values.heimdall.enabled -}}
+{{/*
+Generate a cert for Heimdall on install of Chart
+  TODO: Create RBAC rule to limit secret access to heimdall Pods
+*/}}
+{{- $heimdallCert := genPrivateKey "rsa" -}}
+
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: heimdall-signer-cert
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "lfx-platform.labels" . | nindent 4 }}
+    app.kubernetes.io/component: heimdall
+  annotations:
+    helm.sh/hook: pre-install
+    helm.sh/hook-weight: "0"
+    helm.sh/hook-delete-policy: before-hook-creation
+data: 
+  "signer.pem": "{{ $heimdallCert | b64enc }}"
+{{- end }}

--- a/charts/lfx-platform/values.yaml
+++ b/charts/lfx-platform/values.yaml
@@ -58,6 +58,13 @@ heimdall:
     replicaCount: 1
     autoscaling:
       enabled: false
+    volumes:
+      - name: heimdall-signer-cert
+        secret:
+          secretName: heimdall-signer-cert
+    volumeMounts:
+      - name: heimdall-signer-cert
+        mountPath: "/heimdall/cert/"
 
   log:
     format: gelf
@@ -81,7 +88,13 @@ heimdall:
         type: allow
       - id: deny_all
         type: deny
-    finalizers: []
+    finalizers:
+      - id: create_jwt
+        type: jwt
+        config:
+          signer:
+            key_store:
+              path: /heimdall/cert/signer.pem
 
   default_rule:
     execute:

--- a/charts/lfx-platform/values.yaml
+++ b/charts/lfx-platform/values.yaml
@@ -100,6 +100,7 @@ heimdall:
     execute:
       - authenticator: anonymous_authenticator
       - authorizer: deny_all
+      - finalizer: create_jwt
 
   extraArgs:
     - "--insecure"


### PR DESCRIPTION
Adds a Helm pre-install hook that creates the necessary Heimdall signer
PEM cert.

Signed-off-by: Trevor Bramwell <tbramwell@linuxfoundation.org>
