### PR TITLE
Enable the Traefik Gateway API and add HTTPRoutes

### DIFF
--- a/charts/lfx-platform/templates/_traefik.tpl
+++ b/charts/lfx-platform/templates/_traefik.tpl
@@ -1,0 +1,64 @@
+{{/*
+Copyright The Linux Foundation and each contributor to LFX.
+SPDX-License-Identifier: MIT
+*/}}
+
+{{/*
+Determine if HTTPS is enabled and get the HTTPS listener name in a single loop
+*/}}
+{{- define "lfx-platform.https-enabled" -}}
+{{- $httpsEnabled := false -}}
+{{- $httpsListener := "websecure" -}}
+{{- if .Values.traefik.gateway.listeners -}}
+  {{- range $name, $listener := .Values.traefik.gateway.listeners -}}
+    {{- if eq $listener.protocol "HTTPS" -}}
+      {{- $httpsEnabled = true -}}
+      {{- $httpsListener = $name -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- $httpsEnabled -}}
+{{- end -}}
+
+{{/*
+Get the HTTPS listener name (sectionName) from gateway listeners
+*/}}
+{{- define "lfx-platform.https-listener" -}}
+{{- $httpsEnabled := false -}}
+{{- $httpsListener := "websecure" -}}
+{{- if .Values.traefik.gateway.listeners -}}
+  {{- range $name, $listener := .Values.traefik.gateway.listeners -}}
+    {{- if eq $listener.protocol "HTTPS" -}}
+      {{- $httpsEnabled = true -}}
+      {{- $httpsListener = $name -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- $httpsListener -}}
+{{- end -}}
+
+{{/*
+Get the HTTP listener name (sectionName) from gateway listeners
+*/}}
+{{- define "lfx-platform.http-listener" -}}
+{{- $httpListener := "web" -}}
+{{- if .Values.traefik.gateway.listeners -}}
+  {{- range $name, $listener := .Values.traefik.gateway.listeners -}}
+    {{- if eq $listener.protocol "HTTP" -}}
+      {{- $httpListener = $name -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- $httpListener -}}
+{{- end -}}
+
+{{/*
+Get the default listener (HTTPS if enabled, otherwise HTTP)
+*/}}
+{{- define "lfx-platform.default-listener" -}}
+{{- if eq (include "lfx-platform.https-enabled" .) "true" -}}
+{{- include "lfx-platform.https-listener" . -}}
+{{- else -}}
+{{- include "lfx-platform.http-listener" . -}}
+{{- end -}}
+{{- end -}}

--- a/charts/lfx-platform/templates/authelia/httproute.yaml
+++ b/charts/lfx-platform/templates/authelia/httproute.yaml
@@ -1,0 +1,22 @@
+# Copyright The Linux Foundation and each contributor to LFX.
+# SPDX-License-Identifier: MIT
+---
+{{ if .Values.authelia_enabled -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: authelia
+  namespace: {{ .Release.Namespace }}
+spec:
+  parentRefs:
+    - name: {{ .Values.traefik.gateway.name }}
+      sectionName: {{ include "lfx-platform.default-listener" . }}
+      namespace: {{ .Release.Namespace }}
+  hostnames:
+    - 'auth.{{ .Values.lfx.domain }}'
+  rules:
+    - backendRefs:
+        - name: lfx-platform-authelia
+          namespace: {{ .Release.Namespace }}
+          port: 80
+{{- end }}

--- a/charts/lfx-platform/templates/authelia/https-redirect-httproute.yaml
+++ b/charts/lfx-platform/templates/authelia/https-redirect-httproute.yaml
@@ -1,0 +1,23 @@
+# Copyright The Linux Foundation and each contributor to LFX.
+# SPDX-License-Identifier: MIT
+---
+{{ if and .Values.authelia_enabled (include "lfx-platform.https-enabled" .) -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: authelia-https-redirect
+  namespace: {{ .Release.Namespace }}
+spec:
+  parentRefs:
+    - name: {{ .Values.traefik.gateway.name }}
+      sectionName: {{ include "lfx-platform.http-listener" . }}
+      namespace: {{ .Release.Namespace }}
+  hostnames:
+    - 'auth.{{ .Values.lfx.domain }}'
+  rules:
+    - filters:
+        - type: RequestRedirect
+          requestRedirect:
+            scheme: https
+            statusCode: 301
+{{- end }}

--- a/charts/lfx-platform/templates/heimdall/middleware.yaml
+++ b/charts/lfx-platform/templates/heimdall/middleware.yaml
@@ -1,0 +1,15 @@
+# Copyright The Linux Foundation and each contributor to LFX.
+# SPDX-License-Identifier: MIT
+---
+{{ if .Values.heimdall.enabled -}}
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: heimdall
+  namespace: {{ .Release.Namespace }}
+spec:
+  forwardAuth:
+    address: "http://lfx-platform-heimdall:4456"
+    authResponseHeaders:
+      - Authorization
+{{- end }}

--- a/charts/lfx-platform/templates/mailpit/httproute.yaml
+++ b/charts/lfx-platform/templates/mailpit/httproute.yaml
@@ -1,0 +1,22 @@
+# Copyright The Linux Foundation and each contributor to LFX.
+# SPDX-License-Identifier: MIT
+---
+{{ if .Values.mailpit.enabled -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: mailpit
+  namespace: {{ .Release.Namespace }}
+spec:
+  parentRefs:
+    - name: {{ .Values.traefik.gateway.name }}
+      sectionName: {{ include "lfx-platform.default-listener" . }}
+      namespace: {{ .Release.Namespace }}
+  hostnames:
+    - 'mailpit.{{ .Values.lfx.domain }}'
+  rules:
+    - backendRefs:
+        - name: lfx-platform-mailpit-http
+          namespace: {{ .Release.Namespace }}
+          port: 80
+{{- end }}

--- a/charts/lfx-platform/templates/mailpit/https-redirect-httproute.yaml
+++ b/charts/lfx-platform/templates/mailpit/https-redirect-httproute.yaml
@@ -1,0 +1,23 @@
+# Copyright The Linux Foundation and each contributor to LFX.
+# SPDX-License-Identifier: MIT
+---
+{{ if and .Values.mailpit.enabled (include "lfx-platform.https-enabled" .) -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: mailpit-https-redirect
+  namespace: {{ .Release.Namespace }}
+spec:
+  parentRefs:
+    - name: {{ .Values.traefik.gateway.name }}
+      sectionName: {{ include "lfx-platform.http-listener" . }}
+      namespace: {{ .Release.Namespace }}
+  hostnames:
+    - 'mailpit.{{ .Values.lfx.domain }}'
+  rules:
+    - filters:
+        - type: RequestRedirect
+          requestRedirect:
+            scheme: https
+            statusCode: 301
+{{- end }}

--- a/charts/lfx-platform/values.yaml
+++ b/charts/lfx-platform/values.yaml
@@ -14,12 +14,28 @@ lfx:
 # Traefik configuration
 traefik:
   enabled: true
-  # Additional traefik configuration can be added here
-  # Values will be merged with the subchart's values
-  ingressRoute:
-    dashboard:
+  providers:
+    # Enable Kubernetes Gateway provider
+    kubernetesGateway:
       enabled: true
-      # Additional dashboard configuration
+    # Disable Kubernetes Ingress provider
+    kubernetesIngress:
+      enabled: false
+  gateway:
+    # Create a default gateway
+    enabled: true
+    name: "lfx-platform-gateway"
+    listeners:
+      web:
+        port: 8000
+        protocol: HTTP
+      traefik:
+        port: 8080
+        protocol: HTTP
+  logs:
+    # Enable access logs
+    access:
+      enabled: true
 
 # OpenFGA configuration
 openfga:
@@ -172,7 +188,6 @@ authelia:
     extraVolumeMounts:
       - name: authelia-users
         mountPath: /config-users
-        subpath: users_database.yml
   configMap:
     log:
       format: json


### PR DESCRIPTION
Uses the new Gateway API with Traefik and disabled the IngressRoute resources.

Adds HTTP routes for Authelia and Mailpit. If a websecure port for traefik is defined, uses HTTPS by default and create HTTPS redirects.

Adds Heimdall Middlware.

Removes the unnecessary 'subpath' key from Authelia volume mounts.