### PR TITLE
use `authelia.enabled`

### DIFF
--- a/charts/lfx-platform/Chart.lock
+++ b/charts/lfx-platform/Chart.lock
@@ -4,10 +4,10 @@ dependencies:
   version: 36.2.0
 - name: openfga
   repository: https://openfga.github.io/helm-charts
-  version: 0.2.37
+  version: 0.2.38
 - name: heimdall
   repository: https://dadrus.github.io/heimdall/charts
-  version: 0.15.6
+  version: 0.15.7
 - name: nats
   repository: https://nats-io.github.io/k8s/helm/charts/
   version: 1.3.9
@@ -16,9 +16,9 @@ dependencies:
   version: 2.34.0
 - name: mailpit
   repository: https://jouve.github.io/charts/
-  version: 0.25.0
+  version: 0.25.2
 - name: authelia
   repository: https://charts.authelia.com
-  version: 0.10.37
-digest: sha256:70d98e61d55843bba04111b9052952de3bb6bf431430f98ed744710cd9edcfd8
-generated: "2025-07-09T12:48:39.176101-07:00"
+  version: 0.10.41
+digest: sha256:d8cd8caf9088b26ae0ce301ddc98b1e0583b51afa5781737a2221d5e7b4e62bb
+generated: "2025-07-21T13:39:49.841356-07:00"

--- a/charts/lfx-platform/Chart.yaml
+++ b/charts/lfx-platform/Chart.yaml
@@ -35,5 +35,5 @@ dependencies:
     condition: mailpit.enabled
   - name: authelia
     repository: https://charts.authelia.com
-    version: ~0.10.34
-    condition: authelia_enabled
+    version: ~0.10.41
+    condition: authelia.enabled

--- a/charts/lfx-platform/templates/authelia-client-secrets.yaml
+++ b/charts/lfx-platform/templates/authelia-client-secrets.yaml
@@ -1,7 +1,7 @@
 # Copyright The Linux Foundation and each contributor to LFX.
 # SPDX-License-Identifier: MIT
 ---
-{{- if and .Values.authelia_enabled .Values.authelia_client_generation.enabled }}
+{{- if and .Values.authelia.enabled .Values.authelia_client_generation.enabled }}
 {{- $client_secrets := dict }}
 {{- range $index, $client := .Values.authelia_client_generation.clients }}
 {{- $client_secrets = set $client_secrets $client (randAlphaNum 32) }}

--- a/charts/lfx-platform/templates/authelia-jwks.yaml
+++ b/charts/lfx-platform/templates/authelia-jwks.yaml
@@ -1,7 +1,7 @@
 # Copyright The Linux Foundation and each contributor to LFX.
 # SPDX-License-Identifier: MIT
 ---
-{{ if and .Values.authelia_enabled .Values.authelia_generate_jwks.enabled }}
+{{ if and .Values.authelia.enabled .Values.authelia_generate_jwks.enabled }}
 {{- $autheliapem := genPrivateKey "rsa" -}}
 
 apiVersion: v1

--- a/charts/lfx-platform/templates/authelia-users.yaml
+++ b/charts/lfx-platform/templates/authelia-users.yaml
@@ -1,7 +1,7 @@
 # Copyright The Linux Foundation and each contributor to LFX.
 # SPDX-License-Identifier: MIT
 ---
-{{- if and .Values.authelia_enabled .Values.authelia_user_generation.enabled }}
+{{- if and .Values.authelia.enabled .Values.authelia_user_generation.enabled }}
 {{- $user_pws := dict }}
 {{- range $index, $username := .Values.authelia_user_generation.users }}
 {{- $user_pws = set $user_pws $username (randAlphaNum 20) }}

--- a/charts/lfx-platform/values.yaml
+++ b/charts/lfx-platform/values.yaml
@@ -147,8 +147,8 @@ mailpit:
   enabled: true
 
 # Authelia configuration
-authelia_enabled: true
 authelia:
+  enabled: true
   ingress:
     enabled: true
     traefikCRD:


### PR DESCRIPTION
Now that it is supported by the upstream authelia chart, we can use `authelia.enabled` instead of `authelia_enabled`

Generated with [GitHub Copilot](https://github.com/features/copilot)