### PR TITLE
Template Heimdall Service URL in Middleware

### DIFF
--- a/charts/lfx-platform/templates/heimdall/middleware.yaml
+++ b/charts/lfx-platform/templates/heimdall/middleware.yaml
@@ -9,7 +9,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   forwardAuth:
-    address: "http://lfx-platform-heimdall:4456"
+    address: "http://{{ include "heimdall.fullname" .Subcharts.heimdall }}.{{ .Release.Namespace }}:4456"
     authResponseHeaders:
       - Authorization
 {{- end }}

--- a/charts/lfx-platform/templates/heimdall/middleware.yaml
+++ b/charts/lfx-platform/templates/heimdall/middleware.yaml
@@ -9,7 +9,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   forwardAuth:
-    address: "http://{{ include "heimdall.fullname" .Subcharts.heimdall }}.{{ .Release.Namespace }}:4456"
+    address: "http://{{ include "heimdall.fullname" .Subcharts.heimdall }}.{{ .Release.Namespace }}:{{ .Values.heimdall.service.main.port }}"
     authResponseHeaders:
       - Authorization
 {{- end }}


### PR DESCRIPTION
Updates the heimdall address in the middleware to use the fullname and
namespace of the service.

Signed-off-by: Trevor Bramwell <tbramwell@linuxfoundation.org>
