### PR TITLE
fix: set k8s ingress to true

### DIFF
--- a/charts/lfx-platform/values.yaml
+++ b/charts/lfx-platform/values.yaml
@@ -29,12 +29,12 @@ traefik:
     # Enable Kubernetes Gateway provider
     kubernetesGateway:
       enabled: true
-    # Disable Kubernetes Ingress provider
+    # Enable Kubernetes Ingress provider
     kubernetesIngress:
-      enabled: false
-    # Disable Kubernetes IngressRoute provider
+      enabled: true
+    # Enable Kubernetes IngressRoute provider
     kubernetesCRD:
-      enabled: false
+      enabled: true
   gateway:
     # Create a default gateway
     enabled: true


### PR DESCRIPTION
This pull request updates the Traefik configuration in the Helm chart values to enable support for additional Kubernetes providers. The main change is that both the Kubernetes Ingress and IngressRoute providers are now enabled, which allows Traefik to route traffic using these mechanisms.

Traefik provider configuration updates:

* Changed `kubernetesIngress.enabled` from `false` to `true`, enabling the Kubernetes Ingress provider.
* Changed `kubernetesCRD.enabled` from `false` to `true`, enabling the Kubernetes IngressRoute (CRD) provider.