### PR TITLE
Ensure Helm dependencies are correctly frozen

### DIFF
--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -29,6 +29,21 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Installs packaged subcharts under charts/${chart}/charts/*.tgz. Also
+      # fails if the Chart.lock digest is wrong. Does not support multiple
+      # charts: `charts/*` is expected to resolve to a single path.
+      - name: Helm dependency fetch
+        shell: bash
+        run: |
+          set -euo pipefail
+          for chart in charts/*; do
+            if [ -f "${chart}/Chart.lock" ]; then
+              yq -r '.dependencies[] | select(.repository | contains("oci://") == false) | "\(.name) \(.repository)"' \
+                "${chart}/Chart.yaml" | xargs -L1 helm repo add
+              helm dependency build "${chart}"
+            fi
+          done
+
       # MegaLinter
       - name: MegaLinter
         id: ml

--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -29,9 +29,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      # Installs packaged subcharts under charts/${chart}/charts/*.tgz. Also
-      # fails if the Chart.lock digest is wrong. Does not support multiple
-      # charts: `charts/*` is expected to resolve to a single path.
+      # Installs packaged subcharts under charts/*/charts/*.tgz. Also
+      # fails if the Chart.lock digest is wrong.
       - name: Helm dependency fetch
         shell: bash
         run: |

--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -38,7 +38,7 @@ jobs:
           for chart in charts/*; do
             if [ -f "${chart}/Chart.lock" ]; then
               yq -r '.dependencies[] | select(.repository | contains("oci://") == false) | "\(.name) \(.repository)"' \
-                "${chart}/Chart.yaml" | xargs -L1 helm repo add
+                "${chart}/Chart.yaml" | xargs -L1 helm repo add --force-update
               helm dependency build "${chart}"
             fi
           done

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Publish Chart to GHCR
         id: publish-ghcr
-        uses: linuxfoundation/lfx-public-workflows/.github/actions/helm-chart-oci-publisher@a5d0271f539e3f69194cca94d9884914c3be088b
+        uses: linuxfoundation/lfx-public-workflows/.github/actions/helm-chart-oci-publisher@e619121ece4ca4b1d6c89ade032f26105505756d
         with:
           name: ${{ steps.prepare.outputs.chart_name }}
           repository: ${{ github.repository }}/chart

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -37,5 +37,3 @@ SPELL_VALE_PRE_COMMANDS:
 FILTER_REGEX_EXCLUDE: '(templates/.*\.yml|templates/.*\.yaml)'
 KUBERNETES_DIRECTORY: charts/lfx-platform
 KUBERNETES_HELM_ARGUMENTS: charts/lfx-platform
-KUBERNETES_HELM_PRE_COMMANDS:
-  - command: helm dependency update charts/lfx-platform

--- a/charts/lfx-platform/Chart.lock
+++ b/charts/lfx-platform/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: traefik
-  repository: https://traefik.github.io/charts
+  repository: oci://ghcr.io/traefik/helm
   version: 36.2.0
 - name: openfga
   repository: https://openfga.github.io/helm-charts
   version: 0.2.39
 - name: heimdall
-  repository: https://dadrus.github.io/heimdall/charts
+  repository: oci://ghcr.io/dadrus/heimdall/chart
   version: 0.15.8
 - name: nats
   repository: https://nats-io.github.io/k8s/helm/charts/
@@ -32,5 +32,5 @@ dependencies:
 - name: trust-manager
   repository: https://charts.jetstack.io
   version: v0.18.0
-digest: sha256:591a323ff20b90c4b50fd92c63788e91d7e08ff2606f155af26e38527680a84d
-generated: "2025-08-06T11:35:55.1914-07:00"
+digest: sha256:62f9779ba2521042d18193fcaa7010ed905045c61579997d6551b2e9c23437fc
+generated: "2025-08-06T13:14:49.133573-07:00"

--- a/charts/lfx-platform/Chart.yaml
+++ b/charts/lfx-platform/Chart.yaml
@@ -9,7 +9,7 @@ version: 0.1.10
 icon: https://github.com/linuxfoundation/lfx-v2-helm/raw/main/img/lfx-logo-color.svg
 dependencies:
   - name: traefik
-    repository: https://traefik.github.io/charts
+    repository: oci://ghcr.io/traefik/helm
     version: ~36.2.0
     condition: traefik.enabled
   - name: openfga
@@ -17,7 +17,7 @@ dependencies:
     version: ~0.2.37
     condition: openfga.enabled
   - name: heimdall
-    repository: https://dadrus.github.io/heimdall/charts
+    repository: oci://ghcr.io/dadrus/heimdall/chart
     version: ~0.15.6
     condition: heimdall.enabled
   - name: nats


### PR DESCRIPTION
- Use "helm repo add" and "helm dependency build" instead of "helm dependency update" before Megalinter run, and move from a Megalinter pre-lint command to the GitHub Actions pipeline.

- Change a couple of our subcharts to use OCI repos to ensure the logic handles them correctly.

- Update packaging to linuxfoundation/lfx-public-workflows#7 to ensure packaging doesn't make changes to the lockfile either.