### PR TITLE
[LFXV2-236] Update OpenFGA authorization model to add new relations for meetings

### DIFF
--- a/charts/lfx-platform/Chart.yaml
+++ b/charts/lfx-platform/Chart.yaml
@@ -5,7 +5,7 @@ apiVersion: v2
 name: lfx-platform
 description: LFX Platform v2 Helm chart
 type: application
-version: 0.1.12
+version: 0.1.13
 icon: https://github.com/linuxfoundation/lfx-v2-helm/raw/main/img/lfx-logo-color.svg
 dependencies:
   - name: traefik

--- a/charts/lfx-platform/Chart.yaml
+++ b/charts/lfx-platform/Chart.yaml
@@ -5,7 +5,7 @@ apiVersion: v2
 name: lfx-platform
 description: LFX Platform v2 Helm chart
 type: application
-version: 0.1.11
+version: 0.1.12
 icon: https://github.com/linuxfoundation/lfx-v2-helm/raw/main/img/lfx-logo-color.svg
 dependencies:
   - name: traefik

--- a/charts/lfx-platform/templates/openfga/model.yaml
+++ b/charts/lfx-platform/templates/openfga/model.yaml
@@ -41,7 +41,7 @@ spec:
             define member: [user]
             define project: [project]
             define writer: writer from project
-            define auditor: auditor from project
+            define auditor: auditor from project or meeting_coordinator from project
             define viewer: [user:*] or auditor from project
 
         type meeting

--- a/charts/lfx-platform/templates/openfga/model.yaml
+++ b/charts/lfx-platform/templates/openfga/model.yaml
@@ -51,7 +51,7 @@ spec:
             define committee: [committee]
             # The organizer relation identifies a user who can manage this one meeting.
             # That means they can update the meeting details, invite/uninvite participants, etc.
-            define organizer: [user, project#meeting_organizer]
+            define organizer: [user] or meeting_organizer from project or writer from project
             # The host relation identifies a user who is a host of this meeting.
             # This is different than the organizer relation because an organizer isn't necessarily
             # the user who is hosting the meeting, nor is the host necessarily the one who is
@@ -61,7 +61,7 @@ spec:
             # The participant relation identifies a user who is a participant in this meeting.
             # This can either mean they are invited to the meeting or they attended the meeting
             # without being invited. In either case, they are a participant of that meeting.
-            define participant: [user, committee#member] or host
+            define participant: [user] or host or member from committee
             # The viewer relation identifies a user who can view this meeting.
             # If the meeting is public, then any user can view it; but if it is private, then
             # only certain privileged users can view it.

--- a/charts/lfx-platform/templates/openfga/model.yaml
+++ b/charts/lfx-platform/templates/openfga/model.yaml
@@ -51,7 +51,7 @@ spec:
             define committee: [committee]
             # The organizer relation identifies a user who can manage this one meeting.
             # That means they can update the meeting details, invite/uninvite participants, etc.
-            define organizer: [user]
+            define organizer: [user, project#meeting_organizer]
             # The host relation identifies a user who is a host of this meeting.
             # This is different than the organizer relation because an organizer isn't necessarily
             # the user who is hosting the meeting, nor is the host necessarily the one who is
@@ -65,5 +65,5 @@ spec:
             # The viewer relation identifies a user who can view this meeting.
             # If the meeting is public, then any user can view it; but if it is private, then
             # only certain privileged users can view it.
-            define viewer: [user:*, committee#member] or participant or organizer or auditor from project
+            define viewer: [user:*] or participant or organizer or auditor from project
 {{- end }}

--- a/charts/lfx-platform/templates/openfga/model.yaml
+++ b/charts/lfx-platform/templates/openfga/model.yaml
@@ -31,10 +31,9 @@ spec:
             define owner: [team#member] or owner from parent
             define writer: [user] or owner or writer from parent
             define auditor: [user, team#member] or writer or auditor from parent
-            # The meeting_organizer relation identifies a user who can manage any meeting
-            # for a given project. This is different than the organizer relation on the meeting
-            # type, which identifies a user who is an organizer of just a single meeting.
-            define meeting_organizer: [user]
+            # The meeting_coordinator relation identifies a user who can manage any meeting
+            # for a given project.
+            define meeting_coordinator: [user]
             define viewer: [user:*] or auditor or auditor from parent
 
         type committee
@@ -51,17 +50,21 @@ spec:
             define committee: [committee]
             # The organizer relation identifies a user who can manage this one meeting.
             # That means they can update the meeting details, invite/uninvite participants, etc.
-            define organizer: [user] or meeting_organizer from project or writer from project
+            define organizer: [user] or meeting_coordinator from project or writer from project
             # The host relation identifies a user who is a host of this meeting.
             # This is different than the organizer relation because an organizer isn't necessarily
             # the user who is hosting the meeting, nor is the host necessarily the one who is
             # organizing the meeting. For example, a host may need to retrieve the Zoom host key
             # but shouldn't be able to update the meeting details.
-            define host: [user]
+            define host: [user] or organizer
             # The participant relation identifies a user who is a participant in this meeting.
             # This can either mean they are invited to the meeting or they attended the meeting
             # without being invited. In either case, they are a participant of that meeting.
-            define participant: [user] or host or member from committee
+            # Note that committee members are not automatically participants of meetings,
+            # because the backend service needs to only include members from the committee
+            # based on the voting status filters of that meeting. That is managed by the backend
+            # services and therefore can't be a relationship in the authorization model.
+            define participant: [user] or host
             # The viewer relation identifies a user who can view this meeting.
             # If the meeting is public, then any user can view it; but if it is private, then
             # only certain privileged users can view it.

--- a/charts/lfx-platform/templates/openfga/model.yaml
+++ b/charts/lfx-platform/templates/openfga/model.yaml
@@ -13,7 +13,7 @@ spec:
   instances:
     - version:
         major: 1
-        minor: 1
+        minor: 2
         patch: 1
       authorizationModel: |
         model

--- a/charts/lfx-platform/templates/openfga/model.yaml
+++ b/charts/lfx-platform/templates/openfga/model.yaml
@@ -31,6 +31,10 @@ spec:
             define owner: [team#member] or owner from parent
             define writer: [user] or owner or writer from parent
             define auditor: [user, team#member] or writer or auditor from parent
+            # The meeting_organizer relation identifies a user who can manage any meeting
+            # for a given project. This is different than the organizer relation on the meeting
+            # type, which identifies a user who is an organizer of just a single meeting.
+            define meeting_organizer: [user]
             define viewer: [user:*] or auditor or auditor from parent
 
         type committee
@@ -45,7 +49,21 @@ spec:
           relations
             define project: [project]
             define committee: [committee]
+            # The organizer relation identifies a user who can manage this one meeting.
+            # That means they can update the meeting details, invite/uninvite participants, etc.
             define organizer: [user]
-            define participant: [user, committee#member]
-            define viewer: [user:*, committee#member] or participant or auditor from project
+            # The host relation identifies a user who is a host of this meeting.
+            # This is different than the organizer relation because an organizer isn't necessarily
+            # the user who is hosting the meeting, nor is the host necessarily the one who is
+            # organizing the meeting. For example, a host may need to retrieve the Zoom host key
+            # but shouldn't be able to update the meeting details.
+            define host: [user]
+            # The participant relation identifies a user who is a participant in this meeting.
+            # This can either mean they are invited to the meeting or they attended the meeting
+            # without being invited. In either case, they are a participant of that meeting.
+            define participant: [user, committee#member] or host
+            # The viewer relation identifies a user who can view this meeting.
+            # If the meeting is public, then any user can view it; but if it is private, then
+            # only certain privileged users can view it.
+            define viewer: [user:*, committee#member] or participant or organizer or auditor from project
 {{- end }}


### PR DESCRIPTION
Changes to authorization model:
- Add `meeting_organizer` relation on project type
- Add `host` relation on meeting type
- Associate `meeting_organizer` relation project type with `organizer` relation on meeting type (meeting_organizer implies organizer)
- Associate `host` relation on meeting type with `participant` relation (host implies participant)
- Associate `organizer` relation on meeting type with `viewer` relation (organizer implies viewer)

fga-sync PR: https://github.com/linuxfoundation/lfx-v2-fga-sync/pull/5

meeting service repo: https://github.com/linuxfoundation/lfx-v2-meeting-service

Ticket: https://linuxfoundation.atlassian.net/browse/LFXV2-236