### PR TITLE
Add LFX v2 Services to Platform Chart

### DIFF
--- a/charts/lfx-platform/Chart.lock
+++ b/charts/lfx-platform/Chart.lock
@@ -43,9 +43,9 @@ dependencies:
   version: 0.2.1
 - name: lfx-v2-access-check
   repository: oci://ghcr.io/linuxfoundation/lfx-v2-access-check/chart
-  version: ~0.2.1
+  version: 0.2.1
 - name: lfx-v2-indexer-service
   repository: oci://ghcr.io/linuxfoundation/lfx-v2-indexer-service/chart
   version: 0.2.0
-digest: sha256:cad0e310627af2343334ff3e9e83a6542527d0cbeff9fa15f391a78a787bcb65
-generated: "2025-08-14T08:24:12.42453939-07:00"
+digest: sha256:6307b6d61090a4a666ce7fcd7f4207491d1335b1ce9b0ebb35f44759728180a3
+generated: "2025-08-14T11:05:40.339603613-07:00"

--- a/charts/lfx-platform/Chart.lock
+++ b/charts/lfx-platform/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 36.2.0
 - name: openfga
   repository: https://openfga.github.io/helm-charts
-  version: 0.2.39
+  version: 0.2.41
 - name: heimdall
   repository: oci://ghcr.io/dadrus/heimdall/chart
   version: 0.15.8
@@ -19,7 +19,7 @@ dependencies:
   version: 0.25.2
 - name: authelia
   repository: https://charts.authelia.com
-  version: 0.10.41
+  version: 0.10.42
 - name: nack
   repository: https://nats-io.github.io/k8s/helm/charts/
   version: 0.29.1
@@ -32,5 +32,20 @@ dependencies:
 - name: trust-manager
   repository: https://charts.jetstack.io
   version: v0.18.0
-digest: sha256:62f9779ba2521042d18193fcaa7010ed905045c61579997d6551b2e9c23437fc
-generated: "2025-08-06T13:14:49.133573-07:00"
+- name: lfx-v2-query-service
+  repository: oci://ghcr.io/linuxfoundation/lfx-v2-query-service/chart
+  version: 0.2.2
+- name: lfx-v2-project-service
+  repository: oci://ghcr.io/linuxfoundation/lfx-v2-project-service/chart
+  version: 0.4.0
+- name: lfx-v2-fga-sync
+  repository: oci://ghcr.io/linuxfoundation/lfx-v2-fga-sync/chart
+  version: 0.2.1
+- name: lfx-v2-access-check
+  repository: oci://ghcr.io/linuxfoundation/lfx-v2-access-check/chart
+  version: 0.1.0
+- name: lfx-v2-indexer-service
+  repository: oci://ghcr.io/linuxfoundation/lfx-v2-indexer-service/chart
+  version: 0.2.0
+digest: sha256:df021ba69425bb313325da7b812ead0ec54ace3fa2b0adee02ed8ef352fa56f0
+generated: "2025-08-13T15:48:40.428224482-07:00"

--- a/charts/lfx-platform/Chart.lock
+++ b/charts/lfx-platform/Chart.lock
@@ -47,5 +47,5 @@ dependencies:
 - name: lfx-v2-indexer-service
   repository: oci://ghcr.io/linuxfoundation/lfx-v2-indexer-service/chart
   version: 0.2.0
-digest: sha256:df021ba69425bb313325da7b812ead0ec54ace3fa2b0adee02ed8ef352fa56f0
-generated: "2025-08-13T15:48:40.428224482-07:00"
+digest: sha256:cad0e310627af2343334ff3e9e83a6542527d0cbeff9fa15f391a78a787bcb65
+generated: "2025-08-14T08:24:12.42453939-07:00"

--- a/charts/lfx-platform/Chart.lock
+++ b/charts/lfx-platform/Chart.lock
@@ -43,7 +43,7 @@ dependencies:
   version: 0.2.1
 - name: lfx-v2-access-check
   repository: oci://ghcr.io/linuxfoundation/lfx-v2-access-check/chart
-  version: 0.1.0
+  version: ~0.2.1
 - name: lfx-v2-indexer-service
   repository: oci://ghcr.io/linuxfoundation/lfx-v2-indexer-service/chart
   version: 0.2.0

--- a/charts/lfx-platform/Chart.yaml
+++ b/charts/lfx-platform/Chart.yaml
@@ -66,7 +66,7 @@ dependencies:
     condition: lfx-v2-fga-sync.enabled
   - name: lfx-v2-access-check
     repository: oci://ghcr.io/linuxfoundation/lfx-v2-access-check/chart
-    version: ~0.1.0
+    version: ~0.2.1
     condition: lfx-v2-access-check.enabled
   - name: lfx-v2-indexer-service
     repository: oci://ghcr.io/linuxfoundation/lfx-v2-indexer-service/chart

--- a/charts/lfx-platform/Chart.yaml
+++ b/charts/lfx-platform/Chart.yaml
@@ -52,3 +52,23 @@ dependencies:
     repository: https://charts.jetstack.io
     version: ~0.18.0
     condition: trustManagerEnabled
+  - name: lfx-v2-query-service
+    repository: oci://ghcr.io/linuxfoundation/lfx-v2-query-service/chart
+    version: ~0.2.2
+    condition: lfx-v2-query-service.enabled
+  - name: lfx-v2-project-service
+    repository: oci://ghcr.io/linuxfoundation/lfx-v2-project-service/chart
+    version: ~0.4.0
+    condition: lfx-v2-project-service.enabled
+  - name: lfx-v2-fga-sync
+    repository: oci://ghcr.io/linuxfoundation/lfx-v2-fga-sync/chart
+    version: ~0.2.0
+    condition: lfx-v2-fga-sync.enabled
+  - name: lfx-v2-access-check
+    repository: oci://ghcr.io/linuxfoundation/lfx-v2-access-check/chart
+    version: ~0.1.0
+    condition: lfx-v2-access-check.enabled
+  - name: lfx-v2-indexer-service
+    repository: oci://ghcr.io/linuxfoundation/lfx-v2-indexer-service/chart
+    version: ~0.2.0
+    condition: lfx-v2-indexer-service.enabled

--- a/charts/lfx-platform/Chart.yaml
+++ b/charts/lfx-platform/Chart.yaml
@@ -5,7 +5,7 @@ apiVersion: v2
 name: lfx-platform
 description: LFX Platform v2 Helm chart
 type: application
-version: 0.1.13
+version: 0.2.0
 icon: https://github.com/linuxfoundation/lfx-v2-helm/raw/main/img/lfx-logo-color.svg
 dependencies:
   - name: traefik

--- a/charts/lfx-platform/values.yaml
+++ b/charts/lfx-platform/values.yaml
@@ -423,18 +423,34 @@ trust-manager:
   crds:
     enabled: true
   namespace: cert-manager
-# Additional services. These will be included in the future when LFX platform
-# services are added.
-additionalServices:
-  enabled: false
-  # The following services will be added in the future
-  # fgaSync:
-  #   enabled: false
-  # accessCheck:
-  #   enabled: false
-  # indexer:
-  #   enabled: false
-  # querySvc:
-  #   enabled: false
-  # projectsApi:
-  #   enabled: false
+
+lfx-v2-fga-sync:
+  enabled: true
+  lfx:
+    domain: k8s.orb.local
+
+lfx-v2-access-check:
+  enabled: true
+  lfx:
+    domain: k8s.orb.local
+
+lfx-v2-indexer-service:
+  enabled: true
+  lfx:
+    domain: k8s.orb.local
+
+lfx-v2-query-service:
+  enabled: true
+  image:
+    tag: development
+  lfx:
+    domain: k8s.orb.local
+  authelia:
+    enabled: true
+  heimdall:
+    enabled: true
+
+lfx-v2-project-service:
+  enabled: true
+  lfx:
+    domain: k8s.orb.local

--- a/charts/lfx-platform/values.yaml
+++ b/charts/lfx-platform/values.yaml
@@ -441,8 +441,6 @@ lfx-v2-indexer-service:
 
 lfx-v2-query-service:
   enabled: true
-  image:
-    tag: development
   lfx:
     domain: k8s.orb.local
   authelia:


### PR DESCRIPTION
Add LFX v2 core services as Helm dependencies:
- query-service - v0.2.2
- project-service - v0.4.0
- fga-sync - v0.2.0
- access-check - v0.1.0
- indexer-service - v0.2.0

Removes the 'additionalServices' section in values.yaml in favor of
individual service configurations.

Signed-off-by: Trevor Bramwell <tbramwell@linuxfoundation.org>
