### PR TITLE
Specify the Authelia Password Store Algorithm

### DIFF
--- a/charts/lfx-platform/values.yaml
+++ b/charts/lfx-platform/values.yaml
@@ -336,6 +336,8 @@ authelia:
       file:
         enabled: true
         path: /config-users/users_database.yml
+        password:
+          algorithm: bcrypt
     access_control:
       default_policy: one_factor
     storage:


### PR DESCRIPTION
This needs to explicitly be set to 'bcrypt' in order to read the
passwords, as it defaults to 'argon2'.

Signed-off-by: Trevor Bramwell <tbramwell@linuxfoundation.org>
