### PR TITLE
add swagger-ui integration with proper base path support

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -27,6 +27,7 @@
     "sslmode",
     "subchart",
     "subcharts",
+    "swaggerapi",
     "tcsh",
     "totp",
     "traefik",

--- a/charts/lfx-platform/Chart.yaml
+++ b/charts/lfx-platform/Chart.yaml
@@ -5,7 +5,7 @@ apiVersion: v2
 name: lfx-platform
 description: LFX Platform v2 Helm chart
 type: application
-version: 0.2.2
+version: 0.2.3
 icon: https://github.com/linuxfoundation/lfx-v2-helm/raw/main/img/lfx-logo-color.svg
 dependencies:
   - name: traefik

--- a/charts/lfx-platform/templates/swagger_ui/configmap.yaml
+++ b/charts/lfx-platform/templates/swagger_ui/configmap.yaml
@@ -1,0 +1,106 @@
+# Copyright The Linux Foundation and each contributor to LFX.
+# SPDX-License-Identifier: MIT
+---
+{{- if .Values.lfx.swagger_ui.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: swagger-ui-merge-script
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: swagger_ui
+data:
+  merge-specs.sh: |
+    #!/bin/sh
+    set -e
+
+    echo "Starting OpenAPI spec merge process..."
+
+    # Install openapi-merge-cli and curl
+    echo "Installing openapi-merge-cli and curl..."
+    npm install -g openapi-merge-cli
+    apk add --no-cache curl
+
+    # Create temp directory for config
+    TEMP_DIR="/tmp/specs"
+    mkdir -p $TEMP_DIR
+
+    # Create merge configuration for openapi-merge-cli with URLs
+    echo '{
+      "inputs": [
+    {{- range $index, $spec := .Values.lfx.swagger_ui.specs }}
+        {{- if $index }},{{- end }}
+        {
+          "inputURL": {{ printf "%s/%s" $.Values.lfx.swagger_ui.server $spec | quote }}
+        }
+    {{- end }}
+      ],
+      "output": "shared/openapi-merged.yaml"
+    }' > $TEMP_DIR/merge-config.json
+
+    # Ensure shared directory exists and use openapi-merge-cli to fetch and merge the specs
+    mkdir -p /shared
+    # Create symlink in working directory to point to the shared volume
+    ln -sf /shared $TEMP_DIR/shared
+    echo "Generated config:"
+    cat $TEMP_DIR/merge-config.json
+
+    # Validate all URLs first - fail if any return 404 or are unreachable
+    echo "Validating all OpenAPI spec URLs..."
+    {{- range $index, $spec := .Values.lfx.swagger_ui.specs }}
+    {{- $fullURL := printf "%s/%s" $.Values.lfx.swagger_ui.server $spec }}
+    echo "Checking {{ $fullURL }}..."
+    HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" "{{ $fullURL }}")
+    if [ "$HTTP_CODE" -ne "200" ]; then
+      echo "✗ ERROR: {{ $fullURL }} returned HTTP $HTTP_CODE"
+      exit 1
+    fi
+    echo "✓ {{ $fullURL }} is accessible (HTTP 200)"
+    {{- end }}
+
+    echo "Using openapi-merge-cli for fetching and merging..."
+    cd $TEMP_DIR
+    openapi-merge-cli --config merge-config.json
+
+    echo "OpenAPI spec merge completed!"
+
+    # Install yq for YAML manipulation
+    apk add --no-cache yq
+
+    # Remove the server component so we can add our own
+    yq eval 'del(.servers)' -i /shared/openapi-merged.yaml
+
+    yq eval '.servers = [{"url": "{{ .Values.lfx.swagger_ui.server }}", "description": "Default api server"}]' -i /shared/openapi-merged.yaml
+
+    {{- if .Values.lfx.swagger_ui.auth.enabled }}
+    # Add OAuth2 security scheme to the merged spec
+    echo "Adding OIDC configuration to merged spec..."
+
+    # Merge the auth config into the OpenAPI spec using direct yq operations
+    echo "Merging auth config with OpenAPI spec..."
+
+    # Add components.securitySchemes to the spec with client ID
+    # https://auth.k8s.orb.local/api/oidc/authorization
+    yq eval '.components.securitySchemes.oidc = {"type": "oauth2", "flows": {"implicit": {"authorizationUrl": "{{ .Values.lfx.swagger_ui.auth.authorizationUrl }}", "scopes": {"api:access": "Access to the API"}}}}' -i /shared/openapi-merged.yaml
+
+
+    # Remove global security requirement (endpoints have their own security)
+    yq eval 'del(.security)' -i /shared/openapi-merged.yaml
+
+    # Add oidc as an alternative security option to all endpoints
+    yq eval '.paths[].*.security += [{"oidc": ["api:access"]}]' -i /shared/openapi-merged.yaml
+
+    echo "✓ oidc configuration added to OpenAPI spec"
+    {{- end }}
+
+    echo "Contents of /shared/:"
+    ls -la /shared/
+    if [ -f "/shared/openapi-merged.yaml" ]; then
+      echo "✓ openapi-merged.yaml exists!"
+      echo "File size: $(wc -c < /shared/openapi-merged.yaml) bytes"
+      echo "First few lines:"
+      head -10 /shared/openapi-merged.yaml
+    else
+      echo "✗ openapi-merged.yaml NOT found!"
+    fi
+{{- end }}

--- a/charts/lfx-platform/templates/swagger_ui/deployment.yaml
+++ b/charts/lfx-platform/templates/swagger_ui/deployment.yaml
@@ -1,0 +1,80 @@
+# Copyright The Linux Foundation and each contributor to LFX.
+# SPDX-License-Identifier: MIT
+---
+{{- if .Values.lfx.swagger_ui.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: swagger-ui
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: swagger-ui
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: swagger-ui
+  template:
+    metadata:
+      labels:
+        app: swagger-ui
+    spec:
+      initContainers:
+        - name: spec-merger
+          image: {{ .Values.lfx.swagger_ui.merger.image }}:{{ .Values.lfx.swagger_ui.merger.tag }}
+          command:
+            - /bin/sh
+            - /scripts/merge-specs.sh
+          volumeMounts:
+            - name: shared-volume
+              mountPath: /shared
+            - name: merge-script
+              mountPath: /scripts
+          resources:
+            requests:
+              memory: "64Mi"
+              cpu: "100m"
+            limits:
+              memory: "128Mi"
+              cpu: "200m"
+      containers:
+        - name: swagger-ui
+          image: {{ .Values.lfx.swagger_ui.image }}:{{ .Values.lfx.swagger_ui.tag }}
+          ports:
+            - name: http
+              containerPort: 8080
+          volumeMounts:
+            - name: shared-volume
+              mountPath: /usr/share/nginx/html/spec
+          env:
+            - name: SWAGGER_JSON_URL
+              value: "spec/openapi-merged.yaml"
+            - name: OAUTH_CLIENT_ID
+              value: {{ .Values.lfx.swagger_ui.auth.clientId | quote }}
+          resources:
+            requests:
+              memory: "64Mi"
+              cpu: "100m"
+            limits:
+              memory: "128Mi"
+              cpu: "200m"
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 20
+      volumes:
+        - name: shared-volume
+          emptyDir: {}
+        - name: merge-script
+          configMap:
+            name: swagger-ui-merge-script
+            defaultMode: 0755
+{{- end }}

--- a/charts/lfx-platform/templates/swagger_ui/httproute.yaml
+++ b/charts/lfx-platform/templates/swagger_ui/httproute.yaml
@@ -1,0 +1,44 @@
+# Copyright The Linux Foundation and each contributor to LFX.
+# SPDX-License-Identifier: MIT
+---
+{{- if and .Values.lfx.swagger_ui.enabled (or .Values.gateway.enabled .Values.lfx.parentGateway.enabled) }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: swagger-ui
+  namespace: {{ .Release.Namespace }}
+spec:
+  parentRefs:
+{{- if .Values.gateway.enabled }}
+    - name: {{ .Values.gateway.name | default "lfx-platform-gateway" }}
+      sectionName: {{ include "lfx-platform.default-listener" . }}
+      namespace: {{ .Release.Namespace }}
+{{- else }}
+    - name: {{ .Values.lfx.parentGateway.name }}
+      sectionName: {{ .Values.lfx.parentGateway.sectionName }}
+      namespace: {{ .Values.lfx.parentGateway.namespace }}
+{{- end }}
+  hostnames:
+    - "lfx-api.{{ .Values.lfx.domain }}"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /docs
+      filters:
+        {{- if and .Values.heimdall.enabled .Values.lfx.swagger_ui.auth.enabled }}
+        - type: ExtensionRef
+          extensionRef:
+            group: traefik.io
+            kind: Middleware
+            name: heimdall
+        {{- end }}
+        - type: URLRewrite
+          urlRewrite:
+            path:
+              type: ReplacePrefixMatch
+              replacePrefixMatch: /
+      backendRefs:
+        - name: swagger-ui
+          port: 80
+{{- end }}

--- a/charts/lfx-platform/templates/swagger_ui/ruleset.yaml
+++ b/charts/lfx-platform/templates/swagger_ui/ruleset.yaml
@@ -6,7 +6,7 @@ apiVersion: heimdall.dadrus.github.com/v1alpha4
 kind: RuleSet
 metadata:
   name: lfx-swagger-ui
-  namespace: lfx
+  namespace: {{ .Release.Namespace }}
 spec:
   rules:
     - id: "rule:lfx:swagger_ui:public"

--- a/charts/lfx-platform/templates/swagger_ui/ruleset.yaml
+++ b/charts/lfx-platform/templates/swagger_ui/ruleset.yaml
@@ -1,0 +1,21 @@
+# Copyright The Linux Foundation and each contributor to LFX.
+# SPDX-License-Identifier: MIT
+---
+{{- if and .Values.lfx.swagger_ui.enabled .Values.heimdall.enabled }}
+apiVersion: heimdall.dadrus.github.com/v1alpha4
+kind: RuleSet
+metadata:
+  name: lfx-swagger-ui
+  namespace: lfx
+spec:
+  rules:
+    - id: "rule:lfx:swagger_ui:public"
+      match:
+        methods:
+          - GET
+        routes:
+          - path: /docs/
+          - path: /docs/**
+      execute:
+        - authorizer: allow_all
+{{- end }}

--- a/charts/lfx-platform/templates/swagger_ui/service.yaml
+++ b/charts/lfx-platform/templates/swagger_ui/service.yaml
@@ -1,0 +1,19 @@
+# Copyright The Linux Foundation and each contributor to LFX.
+# SPDX-License-Identifier: MIT
+---
+{{- if .Values.lfx.swagger_ui.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: swagger-ui
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: swagger-ui
+spec:
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8080
+  selector:
+    app: swagger-ui
+{{- end }}

--- a/charts/lfx-platform/values.yaml
+++ b/charts/lfx-platform/values.yaml
@@ -31,9 +31,6 @@ lfx:
       domain: "https://auth.k8s.orb.local"
       authorizationUrl: "https://auth.k8s.orb.local/api/oidc/authorization"
       clientId: "docs"
-      audience: "http://lfx-api.k8s.orb.local"
-      scope: "openid profile email api:access"
-      redirectUri: "http://lfx-api.k8s.orb.local/docs/oauth2_redirect.html"
     server: "http://lfx-api.k8s.orb.local"
     specs:
       - "_projects/openapi3.yaml"

--- a/charts/lfx-platform/values.yaml
+++ b/charts/lfx-platform/values.yaml
@@ -19,6 +19,26 @@ lfx:
   whoami:
     enabled: true
 
+  swagger_ui:
+    enabled: true
+    image: swaggerapi/swagger-ui
+    tag: latest
+    merger:
+      image: node
+      tag: 24-alpine
+    auth:
+      enabled: true
+      domain: "https://auth.k8s.orb.local"
+      authorizationUrl: "https://auth.k8s.orb.local/api/oidc/authorization"
+      clientId: "docs"
+      audience: "http://lfx-api.k8s.orb.local"
+      scope: "openid profile email api:access"
+      redirectUri: "http://lfx-api.k8s.orb.local/docs/oauth2_redirect.html"
+    server: "http://lfx-api.k8s.orb.local"
+    specs:
+      - "_projects/openapi3.yaml"
+      - "_query/openapi3.yaml"
+
   # Tells rulesets to use the oidc_contextualizer, needed for
   # local dev with authelia
   use_oidc_contextualizer: true
@@ -420,6 +440,26 @@ authelia:
               - refresh_token
             authorization_policy: one_factor
             token_endpoint_auth_method: client_secret_basic
+          - client_id: docs
+            client_name: LFX Swagger UI Docs
+            public: true
+            redirect_uris:
+              - "http://lfx-api.k8s.orb.local/docs/oauth2-redirect.html"
+              - "https://lfx-api.k8s.orb.local/docs/oauth2-redirect.html"
+            scopes:
+              - openid
+              - email
+              - profile
+              - api:access
+            audience:
+              - "http://lfx-api.k8s.orb.local"
+            grant_types:
+              - implicit
+            authorization_policy: one_factor
+            response_types:
+              - code
+              - id_token
+              - token
 
 authelia_generate_jwks:
   enabled: true


### PR DESCRIPTION
Add standalone swagger-ui deployment alongside existing redocly setup:
- Configure swagger-ui to handle /docs/ base path via URLRewrite filter
- Include spec merger init container for OpenAPI aggregation
- Add OIDC authentication support through authelia client
- Create dedicated HTTPRoute with path prefix matching and rewriting
- Add heimdall ruleset for public access to documentation

🤖 Generated with [Claude Code](https://claude.ai/code)