### PR TITLE
added the groupsio_service object for the mailing list permission

### DIFF
--- a/charts/lfx-platform/templates/openfga/model.yaml
+++ b/charts/lfx-platform/templates/openfga/model.yaml
@@ -44,6 +44,14 @@ spec:
             define auditor: auditor from project or meeting_coordinator from project
             define viewer: [user:*] or auditor from project
 
+        type groupsio_service
+          relations
+            define project: [project]
+            define owner: owner from project
+            define writer: writer from project or owner
+            define auditor: auditor from project or writer
+            define viewer: [user:*] or auditor from project
+
         type meeting
           relations
             define project: [project]


### PR DESCRIPTION
Issue - https://linuxfoundation.atlassian.net/browse/LFXV2-28
This pull request adds a new authorization model type for the Groups.io service to the OpenFGA model configuration. The new type defines how permissions and roles are inherited from the `project` type, ensuring consistent access control for Groups.io-related resources.

Authorization model update:

* Added a new `groupsio_service` type to the OpenFGA model, including relations for `project`, `owner`, `writer`, `auditor`, and `viewer`, with role inheritance patterns based on the `project` type.