### PR TITLE
Document Version bumping for the OpenFGA Model

### DIFF
--- a/charts/lfx-platform/templates/openfga/model.yaml
+++ b/charts/lfx-platform/templates/openfga/model.yaml
@@ -11,6 +11,13 @@ metadata:
     app.kubernetes.io/component: openfga
 spec:
   instances:
+{{/*
+  Each change to the authorization model should be accompanied by a version bump.
+  These are the recommended guidelines for versioning:
+    - major: Modifications, deletions, or additions of type
+    - minor: Additions or deletions of relations
+    - patch: Modifications of define
+*/}}
     - version:
         major: 1
         minor: 2


### PR DESCRIPTION
Adds a comment to the OpenFGA AuthorizationModel documenting
recommended versioning.

Signed-off-by: Trevor Bramwell <tbramwell@linuxfoundation.org>
