### PR TITLE
Release the openFGA permission models

### DIFF
--- a/charts/lfx-platform/Chart.yaml
+++ b/charts/lfx-platform/Chart.yaml
@@ -5,7 +5,7 @@ apiVersion: v2
 name: lfx-platform
 description: LFX Platform v2 Helm chart
 type: application
-version: 0.2.2
+version: 0.2.3
 icon: https://github.com/linuxfoundation/lfx-v2-helm/raw/main/img/lfx-logo-color.svg
 dependencies:
   - name: traefik

--- a/charts/lfx-platform/templates/openfga/model.yaml
+++ b/charts/lfx-platform/templates/openfga/model.yaml
@@ -47,7 +47,7 @@ spec:
         type groupsio_service
           relations
             define project: [project]
-            define owner: [user] or owner from project
+            define owner: owner from project
             define writer: writer from project or owner
             define auditor: auditor from project or writer
             define viewer: [user:*] or auditor from project

--- a/charts/lfx-platform/templates/openfga/model.yaml
+++ b/charts/lfx-platform/templates/openfga/model.yaml
@@ -12,9 +12,9 @@ metadata:
 spec:
   instances:
     - version:
-        major: 1
-        minor: 2
-        patch: 1
+        major: 2
+        minor: 0
+        patch: 0
       authorizationModel: |
         model
           schema 1.1
@@ -47,7 +47,7 @@ spec:
         type groupsio_service
           relations
             define project: [project]
-            define owner: owner from project
+            define owner: [user] or owner from project
             define writer: writer from project or owner
             define auditor: auditor from project or writer
             define viewer: [user:*] or auditor from project


### PR DESCRIPTION
Issue - https://linuxfoundation.atlassian.net/browse/LFXV2-350
This pull request updates the LFX Platform Helm chart and its OpenFGA model to support the latest OpenFGA version and expands group ownership logic. The most significant changes are the upgrade to OpenFGA 2.0.0 and a modification to the authorization model to allow direct user ownership in `groupsio_service`.

**OpenFGA Version Upgrade:**
* Updated the OpenFGA model version from 1.2.1 to 2.0.0 in `openfga/model.yaml`, ensuring compatibility with the latest features and improvements.

**Authorization Model Enhancements:**
* Modified the `groupsio_service` definition in the OpenFGA model to allow the `owner` relation to be assigned directly to a `user` or inherited from the project, expanding flexibility in ownership assignment.

**Helm Chart Versioning:**
* Bumped the Helm chart version from `0.2.2` to `0.2.3` in `Chart.yaml` to reflect these updates.