### PR TITLE
added the groupsio mailing list model

### DIFF
--- a/charts/lfx-platform/Chart.yaml
+++ b/charts/lfx-platform/Chart.yaml
@@ -5,7 +5,7 @@ apiVersion: v2
 name: lfx-platform
 description: LFX Platform v2 Helm chart
 type: application
-version: 0.2.4
+version: 0.2.5
 icon: https://github.com/linuxfoundation/lfx-v2-helm/raw/main/img/lfx-logo-color.svg
 dependencies:
   - name: traefik

--- a/charts/lfx-platform/templates/openfga/model.yaml
+++ b/charts/lfx-platform/templates/openfga/model.yaml
@@ -12,7 +12,7 @@ metadata:
 spec:
   instances:
     - version:
-        major: 3
+        major: 4
         minor: 0
         patch: 0
       authorizationModel: |
@@ -51,6 +51,16 @@ spec:
             define writer: writer from project or owner
             define auditor: auditor from project or writer
             define viewer: [user:*] or auditor from project
+
+        type groupsio_mailing_list
+          relations
+            define groupsio_service: [groupsio_service]  # Parent relationship
+            define project: project from groupsio_service # Inherit project permissions
+            define committee: [committee] # Inherit committee permissions
+            define owner: owner from groupsio_service or owner from committee
+            define writer: writer from groupsio_service or writer from committee
+            define auditor: auditor from groupsio_service or auditor from committee
+            define viewer: viewer from groupsio_service or member from committee
 
         type meeting
           relations


### PR DESCRIPTION
Issue - https://linuxfoundation.atlassian.net/browse/LFXV2-351
This pull request introduces a version update to the Helm chart and expands the OpenFGA authorization model to support a new resource type. The most significant changes are the addition of the `groupsio_mailing_list` type and the update of the OpenFGA model version.

**OpenFGA authorization model enhancements:**

* Added a new `groupsio_mailing_list` type with relations for `groupsio_service`, `project`, `committee`, `owner`, `writer`, `auditor`, and `viewer` to extend permission management capabilities for mailing lists.
* Updated the OpenFGA model's major version from 3 to 4 to accommodate the new resource type and relationships.

**Helm chart maintenance:**

* Bumped the Helm chart version from `0.2.4` to `0.2.5` in `Chart.yaml` to reflect these changes.