### PR TITLE
Update chart dependencies

### DIFF
--- a/charts/lfx-platform/Chart.lock
+++ b/charts/lfx-platform/Chart.lock
@@ -19,7 +19,7 @@ dependencies:
   version: 0.25.2
 - name: authelia
   repository: https://charts.authelia.com
-  version: 0.10.44
+  version: 0.10.45
 - name: nack
   repository: https://nats-io.github.io/k8s/helm/charts/
   version: 0.29.2
@@ -40,12 +40,12 @@ dependencies:
   version: 0.4.3
 - name: lfx-v2-fga-sync
   repository: oci://ghcr.io/linuxfoundation/lfx-v2-fga-sync/chart
-  version: 0.2.1
+  version: 0.2.3
 - name: lfx-v2-access-check
   repository: oci://ghcr.io/linuxfoundation/lfx-v2-access-check/chart
   version: 0.2.2
 - name: lfx-v2-indexer-service
   repository: oci://ghcr.io/linuxfoundation/lfx-v2-indexer-service/chart
   version: 0.4.1
-digest: sha256:5d3f71f046ccac29a00cddb34dd9472a57a1c38fc1d92f8e5e784abd61616b80
-generated: "2025-09-08T11:05:46.092768-07:00"
+digest: sha256:e56f9ff6ce85988ae51b50f6efbe9ebbbd7a1832ba46ecc7d5bd57ccb6d5a248
+generated: "2025-09-08T17:15:28.714033-07:00"

--- a/charts/lfx-platform/Chart.yaml
+++ b/charts/lfx-platform/Chart.yaml
@@ -5,7 +5,7 @@ apiVersion: v2
 name: lfx-platform
 description: LFX Platform v2 Helm chart
 type: application
-version: 0.2.8
+version: 0.2.9
 icon: https://github.com/linuxfoundation/lfx-v2-helm/raw/main/img/lfx-logo-color.svg
 dependencies:
   - name: traefik
@@ -58,11 +58,11 @@ dependencies:
     condition: lfx-v2-query-service.enabled
   - name: lfx-v2-project-service
     repository: oci://ghcr.io/linuxfoundation/lfx-v2-project-service/chart
-    version: ~0.4.2
+    version: ~0.4.3
     condition: lfx-v2-project-service.enabled
   - name: lfx-v2-fga-sync
     repository: oci://ghcr.io/linuxfoundation/lfx-v2-fga-sync/chart
-    version: ~0.2.1
+    version: ~0.2.3
     condition: lfx-v2-fga-sync.enabled
   - name: lfx-v2-access-check
     repository: oci://ghcr.io/linuxfoundation/lfx-v2-access-check/chart
@@ -70,5 +70,5 @@ dependencies:
     condition: lfx-v2-access-check.enabled
   - name: lfx-v2-indexer-service
     repository: oci://ghcr.io/linuxfoundation/lfx-v2-indexer-service/chart
-    version: ~0.4.0
+    version: ~0.4.1
     condition: lfx-v2-indexer-service.enabled


### PR DESCRIPTION
This pull request updates the `lfx-platform` Helm chart to version 0.2.9 and bumps several dependent service chart versions to include recent improvements and bug fixes.

Helm chart version update:

* Updated the main chart version in `Chart.yaml` from `0.2.8` to `0.2.9` to reflect the new release.

Dependency updates:

* Bumped `lfx-v2-project-service` dependency version from `~0.4.2` to `~0.4.3`.
* Bumped `lfx-v2-fga-sync` dependency version from `~0.2.1` to `~0.2.3`.
* Bumped `lfx-v2-indexer-service` dependency version from `~0.4.0` to `~0.4.1`.