### PR TITLE
feat: Add groupsio_member authorization model and bump version to 5.0.0

### DIFF
--- a/charts/lfx-platform/Chart.yaml
+++ b/charts/lfx-platform/Chart.yaml
@@ -5,7 +5,7 @@ apiVersion: v2
 name: lfx-platform
 description: LFX Platform v2 Helm chart
 type: application
-version: 0.2.9
+version: 0.2.10
 icon: https://github.com/linuxfoundation/lfx-v2-helm/raw/main/img/lfx-logo-color.svg
 dependencies:
   - name: traefik

--- a/charts/lfx-platform/templates/openfga/model.yaml
+++ b/charts/lfx-platform/templates/openfga/model.yaml
@@ -19,8 +19,8 @@ spec:
     - patch: Modifications of define
 */}}
     - version:
-        major: 4
-        minor: 1
+        major: 5
+        minor: 0
         patch: 0
       authorizationModel: |
         model
@@ -69,6 +69,14 @@ spec:
             define writer: writer from groupsio_service or writer from committee
             define auditor: auditor from groupsio_service or auditor from committee
             define viewer: viewer from groupsio_service or member from committee
+
+        type groupsio_member
+          relations
+            define groupsio_mailing_list: [groupsio_mailing_list]  # Parent relationship
+            define owner: owner from groupsio_mailing_list
+            define writer: [user] or writer from groupsio_mailing_list
+            define auditor: [user] or auditor from groupsio_mailing_list
+            define viewer: viewer from groupsio_mailing_list
 
         type meeting
           relations


### PR DESCRIPTION
Issue - https://linuxfoundation.atlassian.net/browse/LFXV2-352
This pull request updates the LFX Platform Helm chart and makes changes to the OpenFGA authorization model. The main updates include a version bump for the chart, an upgrade to the OpenFGA model version, and the addition of a new `groupsio_member` type with its associated relationships.

**Chart version update:**

* Bumped the Helm chart version for `lfx-platform` from `0.2.9` to `0.2.10` in `Chart.yaml`.

**OpenFGA authorization model changes:**

* Upgraded the OpenFGA model version from `4.1.0` to `5.0.0` in `openfga/model.yaml`.
* Added a new `groupsio_member` type with defined relationships (`groupsio_mailing_list`, `owner`, `writer`, `auditor`, `viewer`) to the OpenFGA model, enabling finer-grained access control for group members.
