### PR TITLE
fix: enable committee owner relation inheritance from writer

### DIFF
--- a/charts/lfx-platform/Chart.yaml
+++ b/charts/lfx-platform/Chart.yaml
@@ -5,7 +5,7 @@ apiVersion: v2
 name: lfx-platform
 description: LFX Platform v2 Helm chart
 type: application
-version: 0.2.12
+version: 0.2.13
 icon: https://github.com/linuxfoundation/lfx-v2-helm/raw/main/img/lfx-logo-color.svg
 dependencies:
   - name: traefik

--- a/charts/lfx-platform/templates/openfga/model.yaml
+++ b/charts/lfx-platform/templates/openfga/model.yaml
@@ -21,7 +21,7 @@ spec:
     - version:
         major: 4
         minor: 2
-        patch: 1
+        patch: 2
       authorizationModel: |
         model
           schema 1.1
@@ -47,8 +47,8 @@ spec:
           relations
             define member: [user]
             define project: [project]
-            define owner: [user, team#member]
-            define writer: [user] or owner or writer from project
+            define writer: [user] or writer from project
+            define owner: [user, team#member] or writer
             define auditor: [user, team#member] or auditor from project or meeting_coordinator from project
             define viewer: [user:*] or auditor or auditor from project
 


### PR DESCRIPTION
## Overview

* https://linuxfoundation.atlassian.net/browse/LFXV2-485

> Users are unable to delete committees, receiving the error: authorization error: expression 1 failed from Heimdall during the authorization check.

This pull request updates the Helm chart for the LFX Platform and refines the OpenFGA authorization model. The main changes include a version bump for the chart, an update to the OpenFGA model patch version, and adjustments to the relationship definitions in the authorization model to clarify writer and owner roles.

## Test Results

### Before Fix
Committee deletion failed with authorization error:

```http
DELETE /committees/dffdbd39-651d-41c9-86fe-682c8cab880f HTTP/1.1
X-MOCK-LOCAL-PRINCIPAL: project_super_admin
If-Match: 457
Content-Type: application/json
Authorization: Bearer authelia_at_uQm-*****
Host: lfx-api.k8s.orb.local:80

HTTP/1.1 403 Forbidden
Content-Length: 0
Date: Mon, 15 Sep 2025 17:12:16 GMT
```

### Deployment
Applied the OpenFGA model changes:

```bash
mauriciosalomao@Mauricios-MacBook-Pro lfx-v2-helm % helm upgrade -n lfx lfx-platform \
    ./charts/lfx-platform
Release "lfx-platform" has been upgraded. Happy Helming!
NAME: lfx-platform
LAST DEPLOYED: Mon Sep 15 14:21:44 2025
NAMESPACE: lfx
STATUS: deployed
REVISION: 9
NOTES:
Thank you for installing lfx-platform.

Your release is named lfx-platform.
```

### After Fix
#### Authorization Check
OpenFGA now correctly authorizes the `owner` relation:

```http
POST /stores/01K1HE7SPAGFMJGGKE5FJ2MWAJ/check HTTP/1.1

{
  "tuple_key": {
    "user": "user:project_super_admin",
    "relation": "owner",
    "object": "committee:e3c72c0a-2170-4ea2-927d-b828e50c9c30"
  }
}

{"allowed":true,"resolution":""}
```

#### Committee Deletion
Committee deletion now succeeds:

```http
DELETE /committees/e3c72c0a-2170-4ea2-927d-b828e50c9c30 HTTP/1.1
If-Match: 537
Content-Type: application/json
Authorization: Bearer authelia_at_KW-*****
Host: lfx-api.k8s.orb.local:80

HTTP/1.1 204 No Content
Date: Mon, 15 Sep 2025 17:27:55 GMT
X-Request-Id: 27d890f2-3179-415e-a98a-53f3ada9aae6
```

### Summary
✅ **Fixed**: Committee deletion authorization now works correctly  
✅ **Verified**: OpenFGA properly resolves `owner` relation through `writer` inheritance  
✅ **Tested**: End-to-end committee deletion flow returns `204 No Content` as expected