### PR TITLE
Gateway: Quote Listener Hostname, Ensure Port int

### DIFF
--- a/charts/lfx-platform/Chart.yaml
+++ b/charts/lfx-platform/Chart.yaml
@@ -5,7 +5,7 @@ apiVersion: v2
 name: lfx-platform
 description: LFX Platform v2 Helm chart
 type: application
-version: 0.2.13
+version: 0.2.14
 icon: https://github.com/linuxfoundation/lfx-v2-helm/raw/main/img/lfx-logo-color.svg
 dependencies:
   - name: traefik

--- a/charts/lfx-platform/templates/gateway.yaml
+++ b/charts/lfx-platform/templates/gateway.yaml
@@ -22,10 +22,10 @@ spec:
   listeners:
     {{- range $name, $listener := .Values.gateway.listeners }}
     - name: {{ $name }}
-      port: {{ $listener.port }}
+      port: {{ $listener.port | int }}
       protocol: {{ $listener.protocol }}
       {{- if $listener.hostname }}
-      hostname: {{ $listener.hostname }}
+      hostname: {{ $listener.hostname | quote }}
       {{- end }}
       {{- if $listener.allowedRoutes }}
       allowedRoutes:


### PR DESCRIPTION
Updates the Gateway resource to quote each listener hostname and ensure
the port is converted to an integer. This ensures passing a domain with
a wildcard at the beginning (like '*.k8s.orb.local') is properly
handled.

Signed-off-by: Trevor Bramwell <tbramwell@linuxfoundation.org>
