### PR TITLE
[LFXV2-534] Add Auth Service

### DIFF
--- a/charts/lfx-platform/Chart.lock
+++ b/charts/lfx-platform/Chart.lock
@@ -47,5 +47,8 @@ dependencies:
 - name: lfx-v2-indexer-service
   repository: oci://ghcr.io/linuxfoundation/lfx-v2-indexer-service/chart
   version: 0.4.1
-digest: sha256:cc88126fa5d1d9223a02ae768be15e2a16c1e8168e299790b908109d2b85f7b7
-generated: "2025-09-11T12:45:36.624945-07:00"
+- name: lfx-v2-auth-service
+  repository: oci://ghcr.io/linuxfoundation/lfx-v2-auth-service/chart
+  version: 0.1.0
+digest: sha256:07412aa8d2711b6ddb87689ff48b8a1b2778faa86165a08bff9bf3431209323a
+generated: "2025-09-22T13:26:51.901715-03:00"

--- a/charts/lfx-platform/Chart.lock
+++ b/charts/lfx-platform/Chart.lock
@@ -19,7 +19,7 @@ dependencies:
   version: 0.25.2
 - name: authelia
   repository: https://charts.authelia.com
-  version: 0.10.45
+  version: 0.10.46
 - name: nack
   repository: https://nats-io.github.io/k8s/helm/charts/
   version: 0.29.2
@@ -46,9 +46,9 @@ dependencies:
   version: 0.2.3
 - name: lfx-v2-indexer-service
   repository: oci://ghcr.io/linuxfoundation/lfx-v2-indexer-service/chart
-  version: 0.4.1
+  version: 0.4.3
 - name: lfx-v2-auth-service
   repository: oci://ghcr.io/linuxfoundation/lfx-v2-auth-service/chart
   version: 0.1.0
 digest: sha256:07412aa8d2711b6ddb87689ff48b8a1b2778faa86165a08bff9bf3431209323a
-generated: "2025-09-22T13:26:51.901715-03:00"
+generated: "2025-09-22T13:37:14.683072-03:00"

--- a/charts/lfx-platform/Chart.yaml
+++ b/charts/lfx-platform/Chart.yaml
@@ -5,7 +5,7 @@ apiVersion: v2
 name: lfx-platform
 description: LFX Platform v2 Helm chart
 type: application
-version: 0.2.14
+version: 0.2.15
 icon: https://github.com/linuxfoundation/lfx-v2-helm/raw/main/img/lfx-logo-color.svg
 dependencies:
   - name: traefik

--- a/charts/lfx-platform/Chart.yaml
+++ b/charts/lfx-platform/Chart.yaml
@@ -72,3 +72,7 @@ dependencies:
     repository: oci://ghcr.io/linuxfoundation/lfx-v2-indexer-service/chart
     version: ~0.4.1
     condition: lfx-v2-indexer-service.enabled
+  - name: lfx-v2-auth-service
+    repository: oci://ghcr.io/linuxfoundation/lfx-v2-auth-service/chart
+    version: ~0.1.0
+    condition: lfx-v2-auth-service.enabled

--- a/charts/lfx-platform/values.yaml
+++ b/charts/lfx-platform/values.yaml
@@ -529,3 +529,8 @@ lfx-v2-project-service:
   enabled: true
   lfx:
     domain: k8s.orb.local
+
+lfx-v2-auth-service:
+  enabled: true
+  lfx:
+    domain: k8s.orb.local


### PR DESCRIPTION
## Overview

* https://linuxfoundation.atlassian.net/browse/LFXV2-534

This pull request adds support for the new `lfx-v2-auth-service` to the Helm chart for the LFX platform. The changes ensure that the authentication service can be deployed and configured alongside existing services.

**Service integration:**

* Added `lfx-v2-auth-service` as a dependency in the `charts/lfx-platform/Chart.yaml` file, specifying its repository, version, and enabling condition.

**Configuration:**

* Introduced configuration options for `lfx-v2-auth-service` in `charts/lfx-platform/values.yaml`, including enabling the service and setting its domain.