### PR TITLE
[LFXV2-199] Query Service - Org Search - bump chart version

### DIFF
--- a/charts/lfx-platform/Chart.lock
+++ b/charts/lfx-platform/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 36.2.0
 - name: openfga
   repository: https://openfga.github.io/helm-charts
-  version: 0.2.42
+  version: 0.2.43
 - name: heimdall
   repository: oci://ghcr.io/dadrus/heimdall/chart
   version: 0.15.8
@@ -34,7 +34,7 @@ dependencies:
   version: v0.18.0
 - name: lfx-v2-query-service
   repository: oci://ghcr.io/linuxfoundation/lfx-v2-query-service/chart
-  version: 0.2.4
+  version: 0.4.4
 - name: lfx-v2-project-service
   repository: oci://ghcr.io/linuxfoundation/lfx-v2-project-service/chart
   version: 0.4.3
@@ -49,6 +49,6 @@ dependencies:
   version: 0.4.3
 - name: lfx-v2-auth-service
   repository: oci://ghcr.io/linuxfoundation/lfx-v2-auth-service/chart
-  version: 0.1.0
-digest: sha256:07412aa8d2711b6ddb87689ff48b8a1b2778faa86165a08bff9bf3431209323a
-generated: "2025-09-22T13:37:14.683072-03:00"
+  version: 0.1.1
+digest: sha256:5694f4680e1a9e638879d26fbfa8a3ca219e07894971253ded7f302a402db88f
+generated: "2025-09-25T08:36:20.482743-03:00"

--- a/charts/lfx-platform/Chart.yaml
+++ b/charts/lfx-platform/Chart.yaml
@@ -5,7 +5,7 @@ apiVersion: v2
 name: lfx-platform
 description: LFX Platform v2 Helm chart
 type: application
-version: 0.2.15
+version: 0.2.16
 icon: https://github.com/linuxfoundation/lfx-v2-helm/raw/main/img/lfx-logo-color.svg
 dependencies:
   - name: traefik
@@ -54,7 +54,7 @@ dependencies:
     condition: trustManagerEnabled
   - name: lfx-v2-query-service
     repository: oci://ghcr.io/linuxfoundation/lfx-v2-query-service/chart
-    version: ~0.2.3
+    version: ~0.4.4
     condition: lfx-v2-query-service.enabled
   - name: lfx-v2-project-service
     repository: oci://ghcr.io/linuxfoundation/lfx-v2-project-service/chart

--- a/charts/lfx-platform/values.yaml
+++ b/charts/lfx-platform/values.yaml
@@ -524,6 +524,15 @@ lfx-v2-query-service:
     enabled: true
   heimdall:
     enabled: true
+  app:
+    environment:
+      # Organization search is configured to use a mock implementation.
+      # To use Clearbit instead, change ORG_SEARCH_SOURCE to 'clearbit' and
+      # set your actual Clearbit API credential in CLEARBIT_CREDENTIAL.
+      ORG_SEARCH_SOURCE:
+        value: mock
+      CLEARBIT_CREDENTIAL:
+        value: ""
 
 lfx-v2-project-service:
   enabled: true


### PR DESCRIPTION
## Overview

Jira Ticket: https://linuxfoundation.atlassian.net/browse/LFXV2-199

This pull request updates the LFX Platform Helm chart to improve dependency management and configuration flexibility. The main changes include updating the chart version, upgrading the `lfx-v2-query-service` dependency, and adding configuration options for organization search.

**Chart and Dependency Updates:**

* Bumped the Helm chart version from `0.2.15` to `0.2.16` in `Chart.yaml` to reflect the new release.
* Upgraded the `lfx-v2-query-service` dependency version from `~0.2.3` to `~0.4.4` in `Chart.yaml`, ensuring use of the latest features and fixes.

**Configuration Enhancements:**

* Added new environment variables under `lfx-v2-query-service.app.environment` in `values.yaml` to allow switching the organization search source between a mock implementation and Clearbit, and to provide a placeholder for the Clearbit API credential.