### PR TITLE
[LFXV2-587] lfx-v2-auth-service User metadata READ Auth0 - bump  to version 0.2.1

### DIFF
--- a/charts/lfx-platform/Chart.lock
+++ b/charts/lfx-platform/Chart.lock
@@ -49,6 +49,6 @@ dependencies:
   version: 0.4.4
 - name: lfx-v2-auth-service
   repository: oci://ghcr.io/linuxfoundation/lfx-v2-auth-service/chart
-  version: 0.2.0
-digest: sha256:5108d054e0daa04b05b15c61b4976b68818bc0d4f6991da0d93738b63edfd639
-generated: "2025-09-26T15:25:18.04846-03:00"
+  version: 0.2.1
+digest: sha256:4910bb2ac9c059bb3e4beb5067ba6bcca6e7f9b2c76ce91897a7e68d85c680d6
+generated: "2025-09-29T12:29:27.911893-03:00"

--- a/charts/lfx-platform/Chart.yaml
+++ b/charts/lfx-platform/Chart.yaml
@@ -5,7 +5,7 @@ apiVersion: v2
 name: lfx-platform
 description: LFX Platform v2 Helm chart
 type: application
-version: 0.2.17
+version: 0.2.18
 icon: https://github.com/linuxfoundation/lfx-v2-helm/raw/main/img/lfx-logo-color.svg
 dependencies:
   - name: traefik
@@ -74,5 +74,5 @@ dependencies:
     condition: lfx-v2-indexer-service.enabled
   - name: lfx-v2-auth-service
     repository: oci://ghcr.io/linuxfoundation/lfx-v2-auth-service/chart
-    version: ~0.2.0
+    version: ~0.2.1
     condition: lfx-v2-auth-service.enabled


### PR DESCRIPTION
## Overview

Jira Ticket: https://linuxfoundation.atlassian.net/browse/LFXV2-587

Auth Service Release
* https://github.com/linuxfoundation/lfx-v2-auth-service/releases/tag/v0.2.1

This pull request updates the Helm chart version for the LFX Platform and bumps the dependency version for the `lfx-v2-auth-service`. These are minor version updates to ensure the chart and its dependencies are using the latest compatible releases.

* Chart version update:
  * Increased the `version` field in `charts/lfx-platform/Chart.yaml` from `0.2.17` to `0.2.18` to reflect the new chart release.

* Dependency version update:
  * Updated the `lfx-v2-auth-service` dependency version from `~0.2.0` to `~0.2.1` in `charts/lfx-platform/Chart.yaml` to use the latest compatible version of the service.