### PR TITLE
[LFXV2-496, LFXV2-597, LFXV2-598] auth-service - bump version - Authelia Local Dev Support and Email-to-Sub Lookup

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -9,6 +9,7 @@
     "contextualizers",
     "crds",
     "dadrus",
+    "daemonset",
     "dbname",
     "finalizer",
     "gelf",

--- a/charts/lfx-platform/Chart.lock
+++ b/charts/lfx-platform/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 36.2.0
 - name: openfga
   repository: https://openfga.github.io/helm-charts
-  version: 0.2.43
+  version: 0.2.44
 - name: heimdall
   repository: oci://ghcr.io/dadrus/heimdall/chart
   version: 0.15.8
@@ -37,7 +37,7 @@ dependencies:
   version: 0.4.6
 - name: lfx-v2-project-service
   repository: oci://ghcr.io/linuxfoundation/lfx-v2-project-service/chart
-  version: 0.4.3
+  version: 0.4.4
 - name: lfx-v2-fga-sync
   repository: oci://ghcr.io/linuxfoundation/lfx-v2-fga-sync/chart
   version: 0.2.3
@@ -49,6 +49,6 @@ dependencies:
   version: 0.4.4
 - name: lfx-v2-auth-service
   repository: oci://ghcr.io/linuxfoundation/lfx-v2-auth-service/chart
-  version: 0.2.1
-digest: sha256:4910bb2ac9c059bb3e4beb5067ba6bcca6e7f9b2c76ce91897a7e68d85c680d6
-generated: "2025-09-29T12:29:27.911893-03:00"
+  version: 0.2.2
+digest: sha256:e5fbbfdae4b632143a36ed0e54d214030e771ad83d11f28de015c2d52400fe33
+generated: "2025-10-02T09:09:29.437084-03:00"

--- a/charts/lfx-platform/Chart.yaml
+++ b/charts/lfx-platform/Chart.yaml
@@ -74,5 +74,5 @@ dependencies:
     condition: lfx-v2-indexer-service.enabled
   - name: lfx-v2-auth-service
     repository: oci://ghcr.io/linuxfoundation/lfx-v2-auth-service/chart
-    version: ~0.2.1
+    version: ~0.2.2
     condition: lfx-v2-auth-service.enabled

--- a/charts/lfx-platform/Chart.yaml
+++ b/charts/lfx-platform/Chart.yaml
@@ -5,7 +5,7 @@ apiVersion: v2
 name: lfx-platform
 description: LFX Platform v2 Helm chart
 type: application
-version: 0.2.20
+version: 0.2.21
 icon: https://github.com/linuxfoundation/lfx-v2-helm/raw/main/img/lfx-logo-color.svg
 dependencies:
   - name: traefik

--- a/charts/lfx-platform/values.yaml
+++ b/charts/lfx-platform/values.yaml
@@ -551,3 +551,14 @@ lfx-v2-auth-service:
       ## https://github.com/linuxfoundation/lfx-v2-auth-service?tab=readme-ov-file#auth0-configuration
       USER_REPOSITORY_TYPE:
         value: mock
+      # Authelia configuration
+      ## Required when using "authelia" repository type
+      ## For more information, see the [Local Development Support documentation](https://github.com/linuxfoundation/lfx-v2-auth-service/blob/main/README.md#local-development-support)
+      AUTHELIA_CONFIGMAP_NAME:
+        value: authelia-users
+      AUTHELIA_CONFIGMAP_NAMESPACE:
+        value: lfx
+      AUTHELIA_DAEMONSET_NAME:
+        value: lfx-platform-authelia
+      AUTHELIA_SECRET_NAME:
+        value: authelia-users


### PR DESCRIPTION
## Overview

Jira Ticket: https://linuxfoundation.atlassian.net/browse/LFXV2-597
Jira Ticket: https://linuxfoundation.atlassian.net/browse/LFXV2-496
Jira Ticket: https://linuxfoundation.atlassian.net/browse/LFXV2-598

This pull request updates the Helm chart configuration for the `lfx-v2-auth-service` dependency and adds support for Authelia integration in the values file. The most important changes are grouped below:

Dependency update:

* Bumped the `lfx-v2-auth-service` chart version from `~0.2.1` to `~0.2.2` in `charts/lfx-platform/Chart.yaml`, ensuring the latest fixes and features are included.

Authelia integration support:

* Added Authelia-related configuration keys (`AUTHELIA_CONFIGMAP_NAME`, `AUTHELIA_CONFIGMAP_NAMESPACE`, `AUTHELIA_DAEMONSET_NAME`, `AUTHELIA_SECRET_NAME`) to `charts/lfx-platform/values.yaml` under `lfx-v2-auth-service`, enabling easier setup for local development and integration with Authelia as an authentication provider.