### PR TITLE
[LFXV2-603] Add authorization model types for past meeting artifacts

### DIFF
--- a/charts/lfx-platform/Chart.yaml
+++ b/charts/lfx-platform/Chart.yaml
@@ -5,7 +5,7 @@ apiVersion: v2
 name: lfx-platform
 description: LFX Platform v2 Helm chart
 type: application
-version: 0.2.20
+version: 0.2.21
 icon: https://github.com/linuxfoundation/lfx-v2-helm/raw/main/img/lfx-logo-color.svg
 dependencies:
   - name: traefik

--- a/charts/lfx-platform/templates/openfga/model.yaml
+++ b/charts/lfx-platform/templates/openfga/model.yaml
@@ -19,7 +19,7 @@ spec:
     - patch: Modifications of define
 */}}
     - version:
-        major: 4
+        major: 5
         minor: 3
         patch: 1
       authorizationModel: |
@@ -121,4 +121,46 @@ spec:
             # If the past meeting is public, then any user can view it; but if it is private, then
             # only certain privileged users can view it.
             define viewer: [user:*] or attendee or invitee or organizer or auditor
+
+          # The past_meeting_recording type identifies a recording of a past meeting.
+          # Access to a recording is limited to one of the following groups:
+          # - Only meeting hosts
+          # - Only meeting participants
+          # - Public (anyone)
+          type past_meeting_recording
+          relations
+            define past_meeting: [past_meeting]
+            define writer: organizer from past_meeting
+            define auditor: auditor from past_meeting
+            define host: host from past_meeting
+            define participant: invitee from past_meeting or attendee from past_meeting
+            define viewer: [user:*] or participant or host or auditor or writer
+
+          # The past_meeting_transcript type identifies a transcript of a past meeting.
+          # Access to a transcript is limited to one of the following groups:
+          # - Only meeting hosts
+          # - Only meeting participants
+          # - Public (anyone)
+          type past_meeting_transcript
+          relations
+            define past_meeting: [past_meeting]
+            define writer: organizer from past_meeting
+            define auditor: auditor from past_meeting
+            define host: host from past_meeting
+            define participant: invitee from past_meeting or attendee from past_meeting
+            define viewer: [user:*] or participant or host or auditor or writer
+
+          # The past_meeting_summary type identifies a summary of a past meeting.
+          # Access to a summary is limited to one of the following groups:
+          # - Only meeting hosts
+          # - Only meeting participants
+          # - Public (anyone)
+          type past_meeting_summary
+          relations
+            define past_meeting: [past_meeting]
+            define writer: organizer from past_meeting
+            define auditor: auditor from past_meeting
+            define host: host from past_meeting
+            define participant: invitee from past_meeting or attendee from past_meeting
+            define viewer: [user:*] or participant or host or auditor or writer
 {{- end }}

--- a/charts/lfx-platform/templates/openfga/model.yaml
+++ b/charts/lfx-platform/templates/openfga/model.yaml
@@ -134,7 +134,15 @@ spec:
             define auditor: auditor from past_meeting
             define host: host from past_meeting
             define participant: invitee from past_meeting or attendee from past_meeting
-            define viewer: [user:*] or participant or host or auditor or writer
+            # The viewer relation needs to be kept up-to-date separately from the other relations
+            # because it depends on the past meeting visibility.
+            #
+            # If the past meeting is public, then every user should be a viewer
+            # If it is private to only meeting participants, then only the meeting participants
+            # should be able to view the recording.
+            # If it is private to only meeting hosts, then only the meeting hosts should be able
+            # to view the recording.
+            define viewer: [user:*]
 
           # The past_meeting_transcript type identifies a transcript of a past meeting.
           # Access to a transcript is limited to one of the following groups:
@@ -148,7 +156,15 @@ spec:
             define auditor: auditor from past_meeting
             define host: host from past_meeting
             define participant: invitee from past_meeting or attendee from past_meeting
-            define viewer: [user:*] or participant or host or auditor or writer
+            # The viewer relation needs to be kept up-to-date separately from the other relations
+            # because it depends on the past meeting visibility.
+            #
+            # If the past meeting is public, then every user should be a viewer
+            # If it is private to only meeting participants, then only the meeting participants
+            # should be able to view the transcript.
+            # If it is private to only meeting hosts, then only the meeting hosts should be able
+            # to view the transcript.
+            define viewer: [user:*]
 
           # The past_meeting_summary type identifies a summary of a past meeting.
           # Access to a summary is limited to one of the following groups:
@@ -162,5 +178,13 @@ spec:
             define auditor: auditor from past_meeting
             define host: host from past_meeting
             define participant: invitee from past_meeting or attendee from past_meeting
-            define viewer: [user:*] or participant or host or auditor or writer
+            # The viewer relation needs to be kept up-to-date separately from the other relations
+            # because it depends on the past meeting visibility.
+            #
+            # If the past meeting is public, then every user should be a viewer
+            # If it is private to only meeting participants, then only the meeting participants
+            # should be able to view the summary.
+            # If it is private to only meeting hosts, then only the meeting hosts should be able
+            # to view the summary.
+            define viewer: [user:*]
 {{- end }}

--- a/charts/lfx-platform/templates/openfga/model.yaml
+++ b/charts/lfx-platform/templates/openfga/model.yaml
@@ -135,14 +135,15 @@ spec:
             define host: host from past_meeting
             define participant: invitee from past_meeting or attendee from past_meeting
             # The viewer relation needs to be kept up-to-date separately from the other relations
-            # because it depends on the past meeting visibility.
+            # because it depends on the past meeting artifact_visibility setting. Auditors and writers
+            # do however by default have access to view the recording.
             #
             # If the past meeting is public, then every user should be a viewer
             # If it is private to only meeting participants, then only the meeting participants
             # should be able to view the recording.
             # If it is private to only meeting hosts, then only the meeting hosts should be able
             # to view the recording.
-            define viewer: [user:*]
+            define viewer: [user:*] or writer or auditor
 
           # The past_meeting_transcript type identifies a transcript of a past meeting.
           # Access to a transcript is limited to one of the following groups:
@@ -157,14 +158,15 @@ spec:
             define host: host from past_meeting
             define participant: invitee from past_meeting or attendee from past_meeting
             # The viewer relation needs to be kept up-to-date separately from the other relations
-            # because it depends on the past meeting visibility.
+            # because it depends on the past meeting artifact_visibility setting. Auditors and writers
+            # do however by default have access to view the transcript.
             #
             # If the past meeting is public, then every user should be a viewer
             # If it is private to only meeting participants, then only the meeting participants
             # should be able to view the transcript.
             # If it is private to only meeting hosts, then only the meeting hosts should be able
             # to view the transcript.
-            define viewer: [user:*]
+            define viewer: [user:*] or writer or auditor
 
           # The past_meeting_summary type identifies a summary of a past meeting.
           # Access to a summary is limited to one of the following groups:
@@ -179,12 +181,13 @@ spec:
             define host: host from past_meeting
             define participant: invitee from past_meeting or attendee from past_meeting
             # The viewer relation needs to be kept up-to-date separately from the other relations
-            # because it depends on the past meeting visibility.
+            # because it depends on the past meeting artifact_visibility setting. Auditors and writers
+            # do however by default have access to view the summary.
             #
             # If the past meeting is public, then every user should be a viewer
             # If it is private to only meeting participants, then only the meeting participants
             # should be able to view the summary.
             # If it is private to only meeting hosts, then only the meeting hosts should be able
             # to view the summary.
-            define viewer: [user:*]
+            define viewer: [user:*] or writer or auditor
 {{- end }}

--- a/charts/lfx-platform/templates/openfga/model.yaml
+++ b/charts/lfx-platform/templates/openfga/model.yaml
@@ -138,10 +138,10 @@ spec:
             # because it depends on the past meeting artifact_visibility setting. Auditors and writers
             # do however by default have access to view the recording.
             #
-            # If the past meeting is public, then every user should be a viewer
-            # If it is private to only meeting participants, then only the meeting participants
+            # If the artifact_visibility is public, then every user should be a viewer
+            # If it is set to only meeting participants, then only the meeting participants
             # should be able to view the recording.
-            # If it is private to only meeting hosts, then only the meeting hosts should be able
+            # If it is set to only meeting hosts, then only the meeting hosts should be able
             # to view the recording.
             define viewer: [user:*] or writer or auditor
 
@@ -161,10 +161,10 @@ spec:
             # because it depends on the past meeting artifact_visibility setting. Auditors and writers
             # do however by default have access to view the transcript.
             #
-            # If the past meeting is public, then every user should be a viewer
-            # If it is private to only meeting participants, then only the meeting participants
+            # If the artifact_visibility is public, then every user should be a viewer
+            # If it is set to only meeting participants, then only the meeting participants
             # should be able to view the transcript.
-            # If it is private to only meeting hosts, then only the meeting hosts should be able
+            # If it is set to only meeting hosts, then only the meeting hosts should be able
             # to view the transcript.
             define viewer: [user:*] or writer or auditor
 
@@ -184,10 +184,10 @@ spec:
             # because it depends on the past meeting artifact_visibility setting. Auditors and writers
             # do however by default have access to view the summary.
             #
-            # If the past meeting is public, then every user should be a viewer
-            # If it is private to only meeting participants, then only the meeting participants
+            # If the artifact_visibility is public, then every user should be a viewer
+            # If it is set to only meeting participants, then only the meeting participants
             # should be able to view the summary.
-            # If it is private to only meeting hosts, then only the meeting hosts should be able
+            # If it is set to only meeting hosts, then only the meeting hosts should be able
             # to view the summary.
             define viewer: [user:*] or writer or auditor
 {{- end }}


### PR DESCRIPTION
## Summary
- Added three new OpenFGA authorization model types: `past_meeting_recording`, `past_meeting_transcript`, and `past_meeting_summary`
- Each type supports three visibility levels: public (anyone), all participants (invitees and attendees), and only hosts
- Write permissions are limited to organizers from the past meeting
- Auditors and writers always have viewer access regardless of visibility settings
- Bumped authorization model version from 4.3.1 to 5.3.1 (major version bump for new types)

## Ticket
[LFXV2-603](https://linuxfoundation.atlassian.net/browse/LFXV2-603)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[LFXV2-603]: https://linuxfoundation.atlassian.net/browse/LFXV2-603?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ