### PR TITLE
[LFXV2-603] Fix viewer relation for past meeting artifacts

### DIFF
--- a/charts/lfx-platform/templates/openfga/model.yaml
+++ b/charts/lfx-platform/templates/openfga/model.yaml
@@ -21,7 +21,7 @@ spec:
     - version:
         major: 5
         minor: 3
-        patch: 2
+        patch: 3
       authorizationModel: |
         model
           schema 1.1
@@ -143,7 +143,7 @@ spec:
             # should be able to view the recording.
             # If it is set to only meeting hosts, then only the meeting hosts should be able
             # to view the recording.
-            define viewer: [user:*] or writer or auditor
+            define viewer: [user, user:*] or writer or auditor
 
           # The past_meeting_transcript type identifies a transcript of a past meeting.
           # Access to a transcript is limited to one of the following groups:
@@ -166,7 +166,7 @@ spec:
             # should be able to view the transcript.
             # If it is set to only meeting hosts, then only the meeting hosts should be able
             # to view the transcript.
-            define viewer: [user:*] or writer or auditor
+            define viewer: [user, user:*] or writer or auditor
 
           # The past_meeting_summary type identifies a summary of a past meeting.
           # Access to a summary is limited to one of the following groups:
@@ -189,5 +189,5 @@ spec:
             # should be able to view the summary.
             # If it is set to only meeting hosts, then only the meeting hosts should be able
             # to view the summary.
-            define viewer: [user:*] or writer or auditor
+            define viewer: [user, user:*] or writer or auditor
 {{- end }}


### PR DESCRIPTION
## Summary
- Fixed the viewer relation for past_meeting_recording, past_meeting_transcript, and past_meeting_summary types to accept both [user] and [user:*] types
- This allows the backend to create viewer tuples for specific users (e.g., hosts or participants) in addition to the wildcard [user:*] tuple for public visibility
- Bumped the patch version from 5.3.2 to 5.3.3

## Ticket
[LFXV2-603](https://linuxfoundation.atlassian.net/browse/LFXV2-603)

🤖 Generated with [Claude Code](https://claude.com/claude-code)