### PR TITLE
Add v1_sync_helper client

### DIFF
--- a/charts/lfx-platform/Chart.lock
+++ b/charts/lfx-platform/Chart.lock
@@ -52,9 +52,9 @@ dependencies:
   version: 0.2.10
 - name: lfx-v2-meeting-service
   repository: oci://ghcr.io/linuxfoundation/lfx-v2-meeting-service/chart
-  version: 0.5.4
+  version: 0.5.5
 - name: lfx-v2-auth-service
   repository: oci://ghcr.io/linuxfoundation/lfx-v2-auth-service/chart
   version: 0.3.1
-digest: sha256:8f37845d3c1e7af228c040a521c9af729c7e9b9c5de474d5c809fb6d8662e66d
-generated: "2025-11-17T10:14:37.78676-08:00"
+digest: sha256:2db11e15351e78eb3861a2646d1f0aa1af3594afe75aef5847cb995f45288bad
+generated: "2025-11-19T12:42:02.392302-08:00"

--- a/charts/lfx-platform/Chart.yaml
+++ b/charts/lfx-platform/Chart.yaml
@@ -5,7 +5,7 @@ apiVersion: v2
 name: lfx-platform
 description: LFX Platform v2 Helm chart
 type: application
-version: 0.3.10
+version: 0.3.11
 icon: https://github.com/linuxfoundation/lfx-v2-helm/raw/main/img/lfx-logo-color.svg
 dependencies:
   - name: traefik

--- a/charts/lfx-platform/values.yaml
+++ b/charts/lfx-platform/values.yaml
@@ -499,6 +499,19 @@ authelia:
               - code
               - id_token
               - token
+          - client_id: v1_sync_helper
+            client_name: LFX Data Backfill Service
+            client_secret:
+              path: /secrets/authelia-clients-hashed/v1_sync_helper
+            public: false
+            scopes:
+              - none
+            audience:
+              - "http://lfx-api.k8s.orb.local"
+            grant_types:
+              - client_credentials
+            authorization_policy: one_factor
+            token_endpoint_auth_method: client_secret_basic
 
 authelia_generate_jwks:
   enabled: true
@@ -509,6 +522,7 @@ authelia_client_generation:
     - heimdall
     - m2m_test
     - lfx
+    - v1_sync_helper
 
 authelia_user_generation:
   enabled: true


### PR DESCRIPTION
This client is not actually authenticated-to by v1-sync-helper, but that service, which impersonates authenticated users via its own Heimdall-JWT generation, may use this client ID as the authenticated principal in a bearer token if there is no relevant principal to impersonate for a given data update.

Also update Chart dependencies and bump chart version.