### PR TITLE
[LFXV2-501] auth service - bump versions

### DIFF
--- a/charts/lfx-platform/Chart.lock
+++ b/charts/lfx-platform/Chart.lock
@@ -59,5 +59,5 @@ dependencies:
 - name: lfx-v2-auth-service
   repository: oci://ghcr.io/linuxfoundation/lfx-v2-auth-service/chart
   version: 0.3.4
-digest: sha256:95dcbee30e699acc9dbfbd9e7965b67d5126f5940440ad239fcf856d71527574
-generated: "2025-12-30T13:15:23.240513-03:00"
+digest: sha256:8b73e3d14b4ba49313b87f51e1cf47b8d50e29f7d0384fb830900cf54eae9e9d
+generated: "2025-12-30T13:32:30.201772-03:00"

--- a/charts/lfx-platform/Chart.lock
+++ b/charts/lfx-platform/Chart.lock
@@ -55,9 +55,9 @@ dependencies:
   version: 0.5.13
 - name: lfx-v2-mailing-list-service
   repository: oci://ghcr.io/linuxfoundation/lfx-v2-mailing-list-service/chart
-  version: 0.1.1
+  version: 0.1.2
 - name: lfx-v2-auth-service
   repository: oci://ghcr.io/linuxfoundation/lfx-v2-auth-service/chart
-  version: 0.3.3
-digest: sha256:36bc8b5a8a3749d0dac16491c486d68334ba3c75fedc17440dcfe8d6a6c0c290
-generated: "2025-12-29T15:00:24.698017-08:00"
+  version: 0.3.4
+digest: sha256:95dcbee30e699acc9dbfbd9e7965b67d5126f5940440ad239fcf856d71527574
+generated: "2025-12-30T13:15:23.240513-03:00"

--- a/charts/lfx-platform/Chart.yaml
+++ b/charts/lfx-platform/Chart.yaml
@@ -82,9 +82,9 @@ dependencies:
     condition: lfx-v2-meeting-service.enabled
   - name: lfx-v2-mailing-list-service
     repository: oci://ghcr.io/linuxfoundation/lfx-v2-mailing-list-service/chart
-    version: ~0.1.1
+    version: ~0.1.2
     condition: lfx-v2-mailing-list-service.enabled
   - name: lfx-v2-auth-service
     repository: oci://ghcr.io/linuxfoundation/lfx-v2-auth-service/chart
-    version: ~0.3.1
+    version: ~0.3.4
     condition: lfx-v2-auth-service.enabled

--- a/charts/lfx-platform/values.yaml
+++ b/charts/lfx-platform/values.yaml
@@ -656,3 +656,5 @@ lfx-v2-auth-service:
         value: lfx-platform-authelia
       AUTHELIA_SECRET_NAME:
         value: authelia-users
+      AUTHELIA_OIDC_USERINFO_URL:
+        value: https://auth.k8s.orb.local/api/oidc/userinfo


### PR DESCRIPTION
## Overview

Jira Ticket: https://linuxfoundation.atlassian.net/browse/LFXV2-501

This pull request updates dependencies for the mailing list and auth services and introduces a new configuration for the auth service. The main changes are version bumps for two service charts and the addition of a new OIDC user info URL environment variable for the auth service.

Dependency updates:

* Bumped `lfx-v2-mailing-list-service` chart version from `~0.1.1` to `~0.1.2` in `Chart.yaml` to use the latest features and fixes.
* Bumped `lfx-v2-auth-service` chart version from `~0.3.1` to `~0.3.4` in `Chart.yaml` for improved stability and updates.

Configuration changes:

* Added the `AUTHELIA_OIDC_USERINFO_URL` environment variable to `values.yaml` for the auth service, pointing to the user info endpoint (`https://auth.k8s.orb.local/api/oidc/userinfo`).