### PR TITLE
Add Chart.yaml version comment for dynamic replacement

### DIFF
--- a/charts/lfx-platform/Chart.yaml
+++ b/charts/lfx-platform/Chart.yaml
@@ -5,6 +5,7 @@ apiVersion: v2
 name: lfx-platform
 description: LFX Platform v2 Helm chart
 type: application
+# This version should not be incremented, as it is dynamically replaced with the release version during the chart build job.
 version: 0.0.1
 icon: https://github.com/linuxfoundation/lfx-v2-helm/raw/main/img/lfx-logo-color.svg
 dependencies:


### PR DESCRIPTION
## Summary
This PR adds documentation to the Chart.yaml file explaining that the version is dynamically replaced during the chart build process.

## Changes Made
- **Chart.yaml**: Added explanatory comment about dynamic version replacement during build process
- Version remains at `0.0.1` as expected and is dynamically replaced with the actual release version during chart build job

## Expected Behavior
- Chart.yaml version stays at `0.0.1` with clear documentation that it shouldn't be manually incremented
- During release builds, the `helm-chart-oci-publisher` action (already using correct version `@17e4144d7ba68f7c3e8c16eece5aed15fd7c2dc8`) dynamically replaces this version with the actual release version
- This ensures chart versions are always synchronized with application releases

## Related Issues
- **Jira**: LFXV2-872 - Tie chart releases to app releases