### PR TITLE
[LFXV2-1256] Add local development support to lfx-platform Helm chart

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -14,6 +14,7 @@
     "finalizer",
     "gelf",
     "gjson",
+    "GROUPSIO",
     "GOMEMLIMIT",
     "heimdallcfg",
     "jaegertracing",

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 .env
 *.env
 values.local.yaml
+values-secrets.yaml
 
 # Rendered templates
 **/templates/*.rendered

--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@
 .env
 *.env
 values.local.yaml
-values-secrets.yaml
+tmp/
 
 # Rendered templates
 **/templates/*.rendered

--- a/charts/lfx-platform/Chart.lock
+++ b/charts/lfx-platform/Chart.lock
@@ -4,10 +4,10 @@ dependencies:
   version: 36.2.0
 - name: openfga
   repository: https://openfga.github.io/helm-charts
-  version: 0.2.52
+  version: 0.2.55
 - name: heimdall
   repository: oci://ghcr.io/dadrus/heimdall/chart
-  version: 0.16.8
+  version: 0.16.10
 - name: nats
   repository: https://nats-io.github.io/k8s/helm/charts/
   version: 1.3.16
@@ -28,42 +28,42 @@ dependencies:
   version: 1.0.0
 - name: cert-manager
   repository: https://charts.jetstack.io
-  version: v1.18.5
+  version: v1.18.6
 - name: trust-manager
   repository: https://charts.jetstack.io
   version: v0.18.0
 - name: lfx-v2-query-service
   repository: oci://ghcr.io/linuxfoundation/lfx-v2-query-service/chart
-  version: 0.4.9
+  version: 0.4.12
 - name: lfx-v2-project-service
   repository: oci://ghcr.io/linuxfoundation/lfx-v2-project-service/chart
-  version: 0.5.6
+  version: 0.5.7
 - name: lfx-v2-fga-sync
   repository: oci://ghcr.io/linuxfoundation/lfx-v2-fga-sync/chart
-  version: 0.2.12
+  version: 0.2.14
 - name: lfx-v2-access-check
   repository: oci://ghcr.io/linuxfoundation/lfx-v2-access-check/chart
-  version: 0.2.6
+  version: 0.2.8
 - name: lfx-v2-indexer-service
   repository: oci://ghcr.io/linuxfoundation/lfx-v2-indexer-service/chart
-  version: 0.4.14
+  version: 0.4.16
 - name: lfx-v2-committee-service
   repository: oci://ghcr.io/linuxfoundation/lfx-v2-committee-service/chart
-  version: 0.2.19
+  version: 0.2.21
 - name: lfx-v2-meeting-service
   repository: oci://ghcr.io/linuxfoundation/lfx-v2-meeting-service/chart
-  version: 0.5.14
+  version: 0.6.5
 - name: lfx-v2-mailing-list-service
   repository: oci://ghcr.io/linuxfoundation/lfx-v2-mailing-list-service/chart
-  version: 0.1.9
+  version: 0.1.11
 - name: lfx-v2-auth-service
   repository: oci://ghcr.io/linuxfoundation/lfx-v2-auth-service/chart
-  version: 0.3.4
+  version: 0.3.5
 - name: lfx-v2-voting-service
   repository: oci://ghcr.io/linuxfoundation/lfx-v2-voting-service/chart
-  version: 0.1.5
+  version: 0.2.0
 - name: lfx-v2-survey-service
   repository: oci://ghcr.io/linuxfoundation/lfx-v2-survey-service/chart
-  version: 0.1.0
-digest: sha256:4c07a55ece4039bd71d1372e0b9271153003c71063ed7b7d9e85051474b4255d
-generated: "2026-02-04T13:43:15.220177-08:00"
+  version: 0.2.0
+digest: sha256:b0acb7f20518372a5b1bd34403b66f8b1273d76c878d15fb87c6674dfed9a403
+generated: "2026-03-11T17:17:33.151096-07:00"

--- a/charts/lfx-platform/Chart.lock
+++ b/charts/lfx-platform/Chart.lock
@@ -4,10 +4,10 @@ dependencies:
   version: 36.2.0
 - name: openfga
   repository: https://openfga.github.io/helm-charts
-  version: 0.2.55
+  version: 0.2.56
 - name: heimdall
   repository: oci://ghcr.io/dadrus/heimdall/chart
-  version: 0.16.10
+  version: 0.16.11
 - name: nats
   repository: https://nats-io.github.io/k8s/helm/charts/
   version: 1.3.16
@@ -55,18 +55,18 @@ dependencies:
   version: 0.2.21
 - name: lfx-v2-meeting-service
   repository: oci://ghcr.io/linuxfoundation/lfx-v2-meeting-service/chart
-  version: 0.6.5
+  version: 0.7.0
 - name: lfx-v2-mailing-list-service
   repository: oci://ghcr.io/linuxfoundation/lfx-v2-mailing-list-service/chart
-  version: 0.1.11
+  version: 0.2.0
 - name: lfx-v2-auth-service
   repository: oci://ghcr.io/linuxfoundation/lfx-v2-auth-service/chart
   version: 0.3.5
 - name: lfx-v2-voting-service
   repository: oci://ghcr.io/linuxfoundation/lfx-v2-voting-service/chart
-  version: 0.2.0
+  version: 0.2.1
 - name: lfx-v2-survey-service
   repository: oci://ghcr.io/linuxfoundation/lfx-v2-survey-service/chart
-  version: 0.2.0
-digest: sha256:44a148d27c4462a2c92604a8073c27273c39ed81d854da0c6da90e6af24b7dd5
-generated: "2026-03-12T20:59:53.066536-07:00"
+  version: 0.2.1
+digest: sha256:71a05805933c50182d5d59dc397c1e32c8d908e9f53e318f6cc2ed6b805e1774
+generated: "2026-03-16T09:02:41.749722-07:00"

--- a/charts/lfx-platform/Chart.lock
+++ b/charts/lfx-platform/Chart.lock
@@ -26,6 +26,9 @@ dependencies:
 - name: fga-operator
   repository: https://3schwartz.github.io/fga-operator/
   version: 1.0.0
+- name: external-secrets
+  repository: https://charts.external-secrets.io
+  version: 2.1.0
 - name: cert-manager
   repository: https://charts.jetstack.io
   version: v1.18.6
@@ -65,5 +68,5 @@ dependencies:
 - name: lfx-v2-survey-service
   repository: oci://ghcr.io/linuxfoundation/lfx-v2-survey-service/chart
   version: 0.2.0
-digest: sha256:b0acb7f20518372a5b1bd34403b66f8b1273d76c878d15fb87c6674dfed9a403
-generated: "2026-03-11T17:17:33.151096-07:00"
+digest: sha256:44a148d27c4462a2c92604a8073c27273c39ed81d854da0c6da90e6af24b7dd5
+generated: "2026-03-12T20:59:53.066536-07:00"

--- a/charts/lfx-platform/Chart.yaml
+++ b/charts/lfx-platform/Chart.yaml
@@ -55,45 +55,45 @@ dependencies:
     condition: trustManagerEnabled
   - name: lfx-v2-query-service
     repository: oci://ghcr.io/linuxfoundation/lfx-v2-query-service/chart
-    version: ~0.4.9
+    version: ~0.4.12
     condition: lfx-v2-query-service.enabled
   - name: lfx-v2-project-service
     repository: oci://ghcr.io/linuxfoundation/lfx-v2-project-service/chart
-    version: ~0.5.3
+    version: ~0.5.7
     condition: lfx-v2-project-service.enabled
   - name: lfx-v2-fga-sync
     repository: oci://ghcr.io/linuxfoundation/lfx-v2-fga-sync/chart
-    version: ~0.2.5
+    version: ~0.2.14
     condition: lfx-v2-fga-sync.enabled
   - name: lfx-v2-access-check
     repository: oci://ghcr.io/linuxfoundation/lfx-v2-access-check/chart
-    version: ~0.2.4
+    version: ~0.2.8
     condition: lfx-v2-access-check.enabled
   - name: lfx-v2-indexer-service
     repository: oci://ghcr.io/linuxfoundation/lfx-v2-indexer-service/chart
-    version: ~0.4.10
+    version: ~0.4.16
     condition: lfx-v2-indexer-service.enabled
   - name: lfx-v2-committee-service
     repository: oci://ghcr.io/linuxfoundation/lfx-v2-committee-service/chart
-    version: ~0.2.16
+    version: ~0.2.21
     condition: lfx-v2-committee-service.enabled
   - name: lfx-v2-meeting-service
     repository: oci://ghcr.io/linuxfoundation/lfx-v2-meeting-service/chart
-    version: ~0.5.8
+    version: ~0.6.5
     condition: lfx-v2-meeting-service.enabled
   - name: lfx-v2-mailing-list-service
     repository: oci://ghcr.io/linuxfoundation/lfx-v2-mailing-list-service/chart
-    version: ~0.1.1
+    version: ~0.1.10
     condition: lfx-v2-mailing-list-service.enabled
   - name: lfx-v2-auth-service
     repository: oci://ghcr.io/linuxfoundation/lfx-v2-auth-service/chart
-    version: ~0.3.1
+    version: ~0.3.5
     condition: lfx-v2-auth-service.enabled
   - name: lfx-v2-voting-service
     repository: oci://ghcr.io/linuxfoundation/lfx-v2-voting-service/chart
-    version: ~0.1.0
+    version: ~0.2.0
     condition: lfx-v2-voting-service.enabled
   - name: lfx-v2-survey-service
     repository: oci://ghcr.io/linuxfoundation/lfx-v2-survey-service/chart
-    version: ~0.1.0
+    version: ~0.2.0
     condition: lfx-v2-survey-service.enabled

--- a/charts/lfx-platform/Chart.yaml
+++ b/charts/lfx-platform/Chart.yaml
@@ -83,11 +83,11 @@ dependencies:
     condition: lfx-v2-committee-service.enabled
   - name: lfx-v2-meeting-service
     repository: oci://ghcr.io/linuxfoundation/lfx-v2-meeting-service/chart
-    version: ~0.6.5
+    version: ~0.7.0
     condition: lfx-v2-meeting-service.enabled
   - name: lfx-v2-mailing-list-service
     repository: oci://ghcr.io/linuxfoundation/lfx-v2-mailing-list-service/chart
-    version: ~0.1.10
+    version: ~0.2.0
     condition: lfx-v2-mailing-list-service.enabled
   - name: lfx-v2-auth-service
     repository: oci://ghcr.io/linuxfoundation/lfx-v2-auth-service/chart
@@ -95,9 +95,9 @@ dependencies:
     condition: lfx-v2-auth-service.enabled
   - name: lfx-v2-voting-service
     repository: oci://ghcr.io/linuxfoundation/lfx-v2-voting-service/chart
-    version: ~0.2.0
+    version: ~0.2.1
     condition: lfx-v2-voting-service.enabled
   - name: lfx-v2-survey-service
     repository: oci://ghcr.io/linuxfoundation/lfx-v2-survey-service/chart
-    version: ~0.2.0
+    version: ~0.2.1
     condition: lfx-v2-survey-service.enabled

--- a/charts/lfx-platform/Chart.yaml
+++ b/charts/lfx-platform/Chart.yaml
@@ -45,6 +45,10 @@ dependencies:
     repository: https://3schwartz.github.io/fga-operator/
     version: ~1.0.0
     condition: fga-operator.enabled
+  - name: external-secrets
+    repository: https://charts.external-secrets.io
+    version: ~2.1.0
+    condition: external-secrets.enabled
   - name: cert-manager
     repository: https://charts.jetstack.io
     version: ~1.18.2

--- a/charts/lfx-platform/README.md
+++ b/charts/lfx-platform/README.md
@@ -18,10 +18,32 @@ resource APIs for the LFX platform.
 # Create namespace (recommended).
 kubectl create namespace lfx
 
-# Install the chart.
+# Install the latest version of the chart.
+helm install -n lfx lfx-platform \
+  oci://ghcr.io/linuxfoundation/lfx-v2-helm/chart/lfx-platform
+```
+
+#### Local development (resource-constrained machines)
+
+The default `values.yaml` uses production-grade resource limits (e.g. NATS
+requires ~24Gi memory across its 3 replicas). For local development, use the
+bundled `values-local.yaml` override to reduce resource requirements:
+
+```bash
+kubectl create namespace lfx
+
 helm install -n lfx lfx-platform \
   oci://ghcr.io/linuxfoundation/lfx-v2-helm/chart/lfx-platform \
-  --version 0.1.1
+  --values https://raw.githubusercontent.com/linuxfoundation/lfx-v2-helm/main/charts/lfx-platform/values-local.yaml
+```
+
+Alternatively, if you have a local copy of `values-local.yaml` (e.g. after
+cloning the repo), pass it directly:
+
+```bash
+helm install -n lfx lfx-platform \
+  oci://ghcr.io/linuxfoundation/lfx-v2-helm/chart/lfx-platform \
+  --values /path/to/values-local.yaml
 ```
 
 ### Installing from source

--- a/charts/lfx-platform/README.md
+++ b/charts/lfx-platform/README.md
@@ -156,9 +156,9 @@ kubectl delete namespace lfx
 
 ## Configuration
 
-The following table lists the configurable parameters of the LFX Platform chart
-and their default values. You can override these values in your `values.local.yaml`
-or by using the `--set` flag when installing the chart.
+You can override any value in your `values.local.yaml` or by using `--set`
+when installing the chart. The canonical reference for all available parameters
+is the inline comments in [`values.yaml`](charts/lfx-platform/values.yaml).
 
 ### Global parameters
 
@@ -168,74 +168,41 @@ or by using the `--set` flag when installing the chart.
 | `lfx.image.registry`   | Global Docker image registry    | `linuxfoundation` |
 | `lfx.image.pullPolicy` | Global Docker image pull policy | `IfNotPresent`    |
 
-### Subchart configuration
+### Subcharts
 
-#### Traefik
+Each subchart can be enabled or disabled via its `enabled` key. Refer to the
+linked documentation for the full set of configuration options.
 
-| Parameter                                | Description              | Default |
-|------------------------------------------|--------------------------|---------|
-| `traefik.enabled`                        | Enable Traefik           | `true`  |
-| `traefik.ingressRoute.dashboard.enabled` | Enable Traefik dashboard | `true`  |
+#### Infrastructure subcharts
 
-For more Traefik configuration options, see the [Traefik Helm Chart documentation](https://github.com/traefik/traefik-helm-chart).
+| Subchart       | Key             | Enabled by default | Documentation |
+|----------------|-----------------|-------------------|---------------|
+| Traefik        | `traefik`       | `true`            | [Traefik Helm Chart](https://github.com/traefik/traefik-helm-chart) |
+| OpenFGA        | `openfga`       | `true`            | [OpenFGA Helm Chart](https://github.com/openfga/helm-charts) · [Local docs](../../docs/openfga.md) |
+| Heimdall       | `heimdall`      | `true`            | [Heimdall Helm Chart](https://github.com/dadrus/heimdall/tree/main/charts/heimdall) |
+| NATS           | `nats`          | `true`            | [NATS Helm Chart](https://github.com/nats-io/k8s/tree/main/helm/charts/nats) |
+| NACK           | `nack`          | `true`            | [NACK documentation](https://github.com/nats-io/k8s/tree/main/helm/charts/nack) |
+| OpenSearch     | `opensearch`    | `true`            | [OpenSearch Helm Chart](https://github.com/opensearch-project/helm-charts) |
+| Authelia       | `authelia`      | `true`            | [Authelia documentation](https://github.com/authelia/chartrepo/tree/master/charts/authelia) |
+| Mailpit        | `mailpit`       | `true`            | [Mailpit documentation](https://github.com/jouve/charts/tree/main/charts/mailpit) |
+| cert-manager   | `cert-manager`  | `false`           | [cert-manager Helm Chart](https://cert-manager.io/docs/installation/helm/) |
+| fga-operator   | `fga-operator`  | `true`            | — |
 
-#### OpenFGA
+#### LFX service subcharts
 
-| Parameter                          | Description                                      | Default |
-|------------------------------------|--------------------------------------------------|---------|
-| `openfga.enabled`                  | Enable OpenFGA                                   | `true`  |
-| `openfga.postgres.enabled`         | Enable built-in PostgreSQL                       | `true`  |
-| `openfga.datastore.existingSecret` | Secret for external PostgreSQL connection string | `nil`   |
-
-For more OpenFGA configuration options, see the [OpenFGA Helm Chart documentation](https://github.com/openfga/helm-charts).
-
-For information on managing OpenFGA see the [OpenFGA Documentation](../../docs/openfga.md).
-
-#### Heimdall
-
-| Parameter                              | Description                             | Default            |
-|----------------------------------------|-----------------------------------------|--------------------|
-| `heimdall.enabled`                     | Enable Heimdall                         | `true`             |
-| `heimdall.autheliaIntegration.enabled` | Enable Authelia integration             | `true`             |
-| `heimdall.secretsRef`                  | Heimdall secrets reference              | `heimdall-secrets` |
-| `heimdall.certsSecretRef`              | Heimdall certificates secrets reference | `heimdall-certs`   |
-
-For more Heimdall configuration options, see the [Heimdall Helm Chart documentation](https://github.com/dadrus/heimdall/tree/main/charts/heimdall).
-
-#### NATS
-
-| Parameter                | Description             | Default |
-|--------------------------|-------------------------|---------|
-| `nats.enabled`           | Enable NATS             | `true`  |
-| `nats.cluster.enabled`   | Enable NATS clustering  | `true`  |
-| `nats.cluster.replicas`  | Number of NATS replicas | `3`     |
-| `nats.jetstream.enabled` | Enable JetStream        | `true`  |
-
-For more NATS configuration options, see the [NATS Helm Chart documentation](https://github.com/nats-io/k8s/tree/main/helm/charts/nats).
-
-#### Mailpit
-
-| Parameter         | Description    | Default |
-|-------------------|----------------|---------|
-| `mailpit.enabled` | Enable Mailpit | `true`  |
-
-For more mailpit configuration options, see the [Mailpit documentation](https://github.com/jouve/charts/tree/main/charts/mailpit).
-
-#### Authelia
-
-| Parameter          | Description     | Default |
-|--------------------|-----------------|---------|
-| `authelia.enabled` | Enable Authelia | `true`  |
-
-For more authelia configuration options, see the [Authelia documentation](https://github.com/authelia/chartrepo/tree/master/charts/authelia).
-
-#### NACK
-
-| Parameter      | Description | Default |
-|----------------|-------------|---------|
-| `nack.enabled` | Enable Nack | `true`  |
-
-For more NACK configuration options, see the [NACK documentation](https://github.com/nats-io/k8s/tree/main/helm/charts/nack).
+| Subchart                    | Key                           | Enabled by default | Chart |
+|-----------------------------|-------------------------------|-------------------|-------|
+| lfx-v2-auth-service         | `lfx-v2-auth-service`         | `true`            | [lfx-v2-auth-service Helm Chart](https://github.com/linuxfoundation/lfx-v2-auth-service/tree/main/charts/lfx-v2-auth-service) |
+| lfx-v2-fga-sync             | `lfx-v2-fga-sync`             | `true`            | [lfx-v2-fga-sync Helm Chart](https://github.com/linuxfoundation/lfx-v2-fga-sync/tree/main/charts/lfx-v2-fga-sync) |
+| lfx-v2-access-check         | `lfx-v2-access-check`         | `true`            | [lfx-v2-access-check Helm Chart](https://github.com/linuxfoundation/lfx-v2-access-check/tree/main/charts/lfx-v2-access-check) |
+| lfx-v2-indexer-service      | `lfx-v2-indexer-service`      | `true`            | [lfx-v2-indexer-service Helm Chart](https://github.com/linuxfoundation/lfx-v2-indexer-service/tree/main/charts/lfx-v2-indexer-service) |
+| lfx-v2-query-service        | `lfx-v2-query-service`        | `true`            | [lfx-v2-query-service Helm Chart](https://github.com/linuxfoundation/lfx-v2-query-service/tree/main/charts/lfx-v2-query-service) |
+| lfx-v2-project-service      | `lfx-v2-project-service`      | `true`            | [lfx-v2-project-service Helm Chart](https://github.com/linuxfoundation/lfx-v2-project-service/tree/main/charts/lfx-v2-project-service) |
+| lfx-v2-committee-service    | `lfx-v2-committee-service`    | `true`            | [lfx-v2-committee-service Helm Chart](https://github.com/linuxfoundation/lfx-v2-committee-service/tree/main/charts/lfx-v2-committee-service) |
+| lfx-v2-voting-service       | `lfx-v2-voting-service`       | `false`           | [lfx-v2-voting-service Helm Chart](https://github.com/linuxfoundation/lfx-v2-voting-service/tree/main/charts/lfx-v2-voting-service) |
+| lfx-v2-survey-service       | `lfx-v2-survey-service`       | `false`           | [lfx-v2-survey-service Helm Chart](https://github.com/linuxfoundation/lfx-v2-survey-service/tree/main/charts/lfx-v2-survey-service) |
+| lfx-v2-meeting-service      | `lfx-v2-meeting-service`      | `false`           | [lfx-v2-meeting-service Helm Chart](https://github.com/linuxfoundation/lfx-v2-meeting-service/tree/main/charts/lfx-v2-meeting-service) |
+| lfx-v2-mailing-list-service | `lfx-v2-mailing-list-service` | `false`           | [lfx-v2-mailing-list-service Helm Chart](https://github.com/linuxfoundation/lfx-v2-mailing-list-service/tree/main/charts/lfx-v2-mailing-list-service) |
 
 ## Using external PostgreSQL with OpenFGA
 
@@ -249,7 +216,7 @@ kubectl create secret generic openfga-postgresql-client \
   -n lfx
 ```
 
-2. Configure OpenFGA in your values file:
+1. Configure OpenFGA in your values file:
 
 ```yaml
 openfga:

--- a/charts/lfx-platform/README.md
+++ b/charts/lfx-platform/README.md
@@ -23,6 +23,15 @@ helm install -n lfx lfx-platform \
   oci://ghcr.io/linuxfoundation/lfx-v2-helm/chart/lfx-platform
 ```
 
+For reproducible installs or when debugging a specific release, pin the version
+with `--version`:
+
+```bash
+helm install -n lfx lfx-platform \
+  oci://ghcr.io/linuxfoundation/lfx-v2-helm/chart/lfx-platform \
+  --version <version>
+```
+
 #### Local development (resource-constrained machines)
 
 The default `values.yaml` uses production-grade resource limits (e.g. NATS
@@ -31,6 +40,11 @@ bundled `values-local.yaml` override to reduce resource requirements:
 
 ```bash
 kubectl create namespace lfx
+
+# NOTE: This downloads values-local.yaml from the main branch and assumes the
+# OCI chart version you install was built from the same main commit. For strict
+# reproducibility, prefer using a local copy of values-local.yaml from the
+# same tag or commit as your chart release (see example below).
 
 helm install -n lfx lfx-platform \
   oci://ghcr.io/linuxfoundation/lfx-v2-helm/chart/lfx-platform \
@@ -45,6 +59,44 @@ helm install -n lfx lfx-platform \
   oci://ghcr.io/linuxfoundation/lfx-v2-helm/chart/lfx-platform \
   --values /path/to/values-local.yaml
 ```
+
+#### Customizing local development values
+
+`values-local.yaml` provides sensible defaults for local development, but any
+parameter from `values.yaml` can be overridden by passing an additional
+`--values` file after `values-local.yaml`. Later `--values` files take
+precedence over earlier ones, so you only need to specify the values you want
+to change.
+
+For example, to further reduce NATS memory limits or enable a service that is
+disabled by default:
+
+```yaml
+# my-overrides.yaml
+nats:
+  container:
+    env:
+      GOMEMLIMIT: 1GiB
+    merge:
+      resources:
+        requests:
+          memory: 512Mi
+        limits:
+          memory: 1Gi
+
+lfx-v2-query-service:
+  enabled: true
+```
+
+```bash
+helm install -n lfx lfx-platform \
+  oci://ghcr.io/linuxfoundation/lfx-v2-helm/chart/lfx-platform \
+  --values https://raw.githubusercontent.com/linuxfoundation/lfx-v2-helm/main/charts/lfx-platform/values-local.yaml \
+  --values my-overrides.yaml
+```
+
+Refer to the [Configuration](#configuration) section and the inline comments
+in `values.yaml` for all available parameters.
 
 ### Installing from source
 
@@ -168,7 +220,7 @@ kubectl create secret generic openfga-postgresql-client \
   -n lfx
 ```
 
-2. Configure OpenFGA in your values file:
+1. Configure OpenFGA in your values file:
 
 ```yaml
 openfga:

--- a/charts/lfx-platform/README.md
+++ b/charts/lfx-platform/README.md
@@ -10,14 +10,75 @@ resource APIs for the LFX platform.
 - PV provisioner support in the underlying infrastructure (if persistence is
   enabled)
 
+## Secrets setup
+
+Some subcharts require Kubernetes secrets to exist in the namespace before
+installing the chart. These secrets are only needed if the corresponding
+subchart is enabled.
+
+To check whether a subchart is enabled, look for its `enabled` field in
+`charts/lfx-platform/values.yaml`:
+
+```bash
+grep -A1 "lfx-v2-voting-service:" charts/lfx-platform/values.yaml
+# enabled: false  ← skip secret creation if false
+```
+
+Secret values are stored in the **LFX V2** vault in 1Password under the note
+**LFX Platform Chart Values Secrets - Local Development**.
+
+### lfx-v2-voting-service
+
+Requires an Auth0 client ID and RSA private key.
+
+```bash
+kubectl create secret generic lfx-v2-voting-service -n lfx \
+  --from-literal=ITX_CLIENT_ID="<from-1password>" \
+  --from-file=ITX_CLIENT_PRIVATE_KEY=/path/to/private.key
+```
+
+### lfx-v2-survey-service
+
+Requires an Auth0 client ID and RSA private key.
+
+```bash
+kubectl create secret generic lfx-v2-survey-service -n lfx \
+  --from-literal=ITX_CLIENT_ID="<from-1password>" \
+  --from-file=ITX_CLIENT_PRIVATE_KEY=/path/to/private.key
+```
+
+### lfx-v2-meeting-service
+
+Requires an Auth0 client ID and RSA private key.
+
+```bash
+kubectl create secret generic meeting-secrets -n lfx \
+  --from-literal=auth0_client_id="<from-1password>" \
+  --from-file=auth0_client_private_key=/path/to/private.key
+```
+
+### lfx-v2-mailing-list-service
+
+Requires Groups.io credentials and a webhook secret.
+
+```bash
+kubectl create secret generic lfx-v2-mailing-list-service -n lfx \
+  --from-literal=GROUPSIO_EMAIL="<from-1password>" \
+  --from-literal=GROUPSIO_PASSWORD="<from-1password>" \
+  --from-literal=GROUPSIO_WEBHOOK_SECRET="<from-1password>"
+```
+
 ## Installing the chart
+
+First, create the namespace (recommended):
+
+```bash
+kubectl create namespace lfx
+```
 
 ### Installing via the OCI registry
 
 ```bash
-# Create namespace (recommended).
-kubectl create namespace lfx
-
 # Install the latest version of the chart.
 helm install -n lfx lfx-platform \
   oci://ghcr.io/linuxfoundation/lfx-v2-helm/chart/lfx-platform
@@ -32,81 +93,12 @@ helm install -n lfx lfx-platform \
   --version <version>
 ```
 
-#### Local development (resource-constrained machines)
-
-The default `values.yaml` uses production-grade resource limits (e.g. NATS
-requires ~24Gi memory across its 3 replicas). For local development, use the
-bundled `values-local.yaml` override to reduce resource requirements:
-
-```bash
-kubectl create namespace lfx
-
-# NOTE: This downloads values-local.yaml from the main branch and assumes the
-# OCI chart version you install was built from the same main commit. For strict
-# reproducibility, prefer using a local copy of values-local.yaml from the
-# same tag or commit as your chart release (see example below).
-
-helm install -n lfx lfx-platform \
-  oci://ghcr.io/linuxfoundation/lfx-v2-helm/chart/lfx-platform \
-  --values https://raw.githubusercontent.com/linuxfoundation/lfx-v2-helm/main/charts/lfx-platform/values-local.yaml
-```
-
-Alternatively, if you have a local copy of `values-local.yaml` (e.g. after
-cloning the repo), pass it directly:
-
-```bash
-helm install -n lfx lfx-platform \
-  oci://ghcr.io/linuxfoundation/lfx-v2-helm/chart/lfx-platform \
-  --values /path/to/values-local.yaml
-```
-
-#### Customizing local development values
-
-`values-local.yaml` provides sensible defaults for local development, but any
-parameter from `values.yaml` can be overridden by passing an additional
-`--values` file after `values-local.yaml`. Later `--values` files take
-precedence over earlier ones, so you only need to specify the values you want
-to change.
-
-For example, to further reduce NATS memory limits or enable a service that is
-disabled by default:
-
-```yaml
-# my-overrides.yaml
-nats:
-  container:
-    env:
-      GOMEMLIMIT: 1GiB
-    merge:
-      resources:
-        requests:
-          memory: 512Mi
-        limits:
-          memory: 1Gi
-
-lfx-v2-query-service:
-  enabled: true
-```
-
-```bash
-helm install -n lfx lfx-platform \
-  oci://ghcr.io/linuxfoundation/lfx-v2-helm/chart/lfx-platform \
-  --values https://raw.githubusercontent.com/linuxfoundation/lfx-v2-helm/main/charts/lfx-platform/values-local.yaml \
-  --values my-overrides.yaml
-```
-
-Refer to the [Configuration](#configuration) section and the inline comments
-in `values.yaml` for all available parameters.
-
 ### Installing from source
 
 Clone the repository before running the following commands from the root of the
 working directory.
 
 ```bash
-# Create namespace (recommended).
-kubectl create namespace lfx
-
 # Pull down chart dependencies.
 helm dependency update charts/lfx-platform
 
@@ -114,6 +106,43 @@ helm dependency update charts/lfx-platform
 helm install -n lfx lfx-platform \
     ./charts/lfx-platform
 ```
+
+### Customizing local development values
+
+The default `values.yaml` is configured for local development. To override
+specific values for your own environment without committing them, copy the
+bundled example file:
+
+```bash
+cp charts/lfx-platform/values.local.example.yaml charts/lfx-platform/values.local.yaml
+```
+
+`values.local.yaml` is gitignored, so you can freely modify it. Pass it when
+installing from OCI or from source:
+
+```bash
+# From OCI registry
+helm install -n lfx lfx-platform \
+  oci://ghcr.io/linuxfoundation/lfx-v2-helm/chart/lfx-platform \
+  --values charts/lfx-platform/values.local.yaml
+
+# From source
+helm install -n lfx lfx-platform ./charts/lfx-platform \
+  --values charts/lfx-platform/values.local.yaml
+```
+
+Later `--values` files take precedence over earlier ones, so you can also layer
+additional overrides on top:
+
+```bash
+helm install -n lfx lfx-platform \
+  oci://ghcr.io/linuxfoundation/lfx-v2-helm/chart/lfx-platform \
+  --values charts/lfx-platform/values.local.yaml \
+  --values my-overrides.yaml
+```
+
+Refer to the [Configuration](#configuration) section and the inline comments
+in `values.yaml` for all available parameters.
 
 ## Uninstalling the chart
 
@@ -128,8 +157,8 @@ kubectl delete namespace lfx
 ## Configuration
 
 The following table lists the configurable parameters of the LFX Platform chart
-and their default values. You can override these values in your own
-`values.yaml` file or by using the `--set` flag when installing the chart.
+and their default values. You can override these values in your `values.local.yaml`
+or by using the `--set` flag when installing the chart.
 
 ### Global parameters
 

--- a/charts/lfx-platform/README.md
+++ b/charts/lfx-platform/README.md
@@ -185,6 +185,7 @@ linked documentation for the full set of configuration options.
 | OpenSearch     | `opensearch`    | `true`            | [OpenSearch Helm Chart](https://github.com/opensearch-project/helm-charts) |
 | Authelia       | `authelia`      | `true`            | [Authelia documentation](https://github.com/authelia/chartrepo/tree/master/charts/authelia) |
 | Mailpit        | `mailpit`       | `true`            | [Mailpit documentation](https://github.com/jouve/charts/tree/main/charts/mailpit) |
+| External Secrets Operator | `external-secrets` | `false`      | [External Secrets Helm Chart](https://external-secrets.io/latest/introduction/getting-started/) |
 | cert-manager   | `cert-manager`  | `false`           | [cert-manager Helm Chart](https://cert-manager.io/docs/installation/helm/) |
 | fga-operator   | `fga-operator`  | `true`            | — |
 
@@ -199,10 +200,28 @@ linked documentation for the full set of configuration options.
 | lfx-v2-query-service        | `lfx-v2-query-service`        | `true`            | [lfx-v2-query-service Helm Chart](https://github.com/linuxfoundation/lfx-v2-query-service/tree/main/charts/lfx-v2-query-service) |
 | lfx-v2-project-service      | `lfx-v2-project-service`      | `true`            | [lfx-v2-project-service Helm Chart](https://github.com/linuxfoundation/lfx-v2-project-service/tree/main/charts/lfx-v2-project-service) |
 | lfx-v2-committee-service    | `lfx-v2-committee-service`    | `true`            | [lfx-v2-committee-service Helm Chart](https://github.com/linuxfoundation/lfx-v2-committee-service/tree/main/charts/lfx-v2-committee-service) |
-| lfx-v2-voting-service       | `lfx-v2-voting-service`       | `false`           | [lfx-v2-voting-service Helm Chart](https://github.com/linuxfoundation/lfx-v2-voting-service/tree/main/charts/lfx-v2-voting-service) |
-| lfx-v2-survey-service       | `lfx-v2-survey-service`       | `false`           | [lfx-v2-survey-service Helm Chart](https://github.com/linuxfoundation/lfx-v2-survey-service/tree/main/charts/lfx-v2-survey-service) |
-| lfx-v2-meeting-service      | `lfx-v2-meeting-service`      | `false`           | [lfx-v2-meeting-service Helm Chart](https://github.com/linuxfoundation/lfx-v2-meeting-service/tree/main/charts/lfx-v2-meeting-service) |
-| lfx-v2-mailing-list-service | `lfx-v2-mailing-list-service` | `false`           | [lfx-v2-mailing-list-service Helm Chart](https://github.com/linuxfoundation/lfx-v2-mailing-list-service/tree/main/charts/lfx-v2-mailing-list-service) |
+| lfx-v2-voting-service       | `lfx-v2-voting-service`       | `true`            | [lfx-v2-voting-service Helm Chart](https://github.com/linuxfoundation/lfx-v2-voting-service/tree/main/charts/lfx-v2-voting-service) |
+| lfx-v2-survey-service       | `lfx-v2-survey-service`       | `true`            | [lfx-v2-survey-service Helm Chart](https://github.com/linuxfoundation/lfx-v2-survey-service/tree/main/charts/lfx-v2-survey-service) |
+| lfx-v2-meeting-service      | `lfx-v2-meeting-service`      | `true`            | [lfx-v2-meeting-service Helm Chart](https://github.com/linuxfoundation/lfx-v2-meeting-service/tree/main/charts/lfx-v2-meeting-service) |
+| lfx-v2-mailing-list-service | `lfx-v2-mailing-list-service` | `true`            | [lfx-v2-mailing-list-service Helm Chart](https://github.com/linuxfoundation/lfx-v2-mailing-list-service/tree/main/charts/lfx-v2-mailing-list-service) |
+
+#### Developing a service locally
+
+When working on a specific service, you can disable its subchart here and
+deploy it directly from the service repository instead. This lets you iterate
+on local code changes without affecting the rest of the platform.
+
+For example, to develop `lfx-v2-query-service` locally:
+
+Disable it in your `values.local.yaml`:
+
+```yaml
+lfx-v2-query-service:
+  enabled: false
+```
+
+Follow the local development instructions in the service repository to
+build and deploy it against the running platform.
 
 ## Using external PostgreSQL with OpenFGA
 

--- a/charts/lfx-platform/README.md
+++ b/charts/lfx-platform/README.md
@@ -220,7 +220,7 @@ kubectl create secret generic openfga-postgresql-client \
   -n lfx
 ```
 
-1. Configure OpenFGA in your values file:
+2. Configure OpenFGA in your values file:
 
 ```yaml
 openfga:

--- a/charts/lfx-platform/README.md
+++ b/charts/lfx-platform/README.md
@@ -158,7 +158,7 @@ kubectl delete namespace lfx
 
 You can override any value in your `values.local.yaml` or by using `--set`
 when installing the chart. The canonical reference for all available parameters
-is the inline comments in [`values.yaml`](charts/lfx-platform/values.yaml).
+is the inline comments in [`values.yaml`](values.yaml).
 
 ### Global parameters
 
@@ -185,7 +185,7 @@ linked documentation for the full set of configuration options.
 | OpenSearch     | `opensearch`    | `true`            | [OpenSearch Helm Chart](https://github.com/opensearch-project/helm-charts) |
 | Authelia       | `authelia`      | `true`            | [Authelia documentation](https://github.com/authelia/chartrepo/tree/master/charts/authelia) |
 | Mailpit        | `mailpit`       | `true`            | [Mailpit documentation](https://github.com/jouve/charts/tree/main/charts/mailpit) |
-| External Secrets Operator | `external-secrets` | `false`      | [External Secrets Helm Chart](https://external-secrets.io/latest/introduction/getting-started/) |
+| External Secrets Operator | `external-secrets` | `true`       | [External Secrets Helm Chart](https://external-secrets.io/latest/introduction/getting-started/) |
 | cert-manager   | `cert-manager`  | `false`           | [cert-manager Helm Chart](https://cert-manager.io/docs/installation/helm/) |
 | fga-operator   | `fga-operator`  | `true`            | — |
 

--- a/charts/lfx-platform/values-local.yaml
+++ b/charts/lfx-platform/values-local.yaml
@@ -1,0 +1,69 @@
+# Copyright The Linux Foundation and each contributor to LFX.
+# SPDX-License-Identifier: MIT
+---
+# Local development overrides for lfx-platform.
+#
+# Use this file when installing the chart on a local machine to reduce
+# resource requirements. Pass it alongside the chart install:
+#
+#   helm install -n lfx lfx-platform \
+#     oci://ghcr.io/linuxfoundation/lfx-v2-helm/chart/lfx-platform \
+#     --version <version> \
+#     --values values-local.yaml
+#
+# Or from source:
+#
+#   helm install -n lfx lfx-platform ./charts/lfx-platform \
+#     --values charts/lfx-platform/values-local.yaml
+
+# NATS configuration — reduced resources for local development
+# Production defaults require ~24Gi memory (3 replicas × 8Gi limit).
+# These settings are suitable for local machines with limited RAM.
+nats:
+  container:
+    env:
+      # Should be ~80% of the memory limit below
+      GOMEMLIMIT: 2GiB
+    merge:
+      resources:
+        requests:
+          cpu: "500m"
+          memory: 1Gi
+        limits:
+          cpu: "1000m"
+          memory: 2Gi
+  config:
+    jetstream:
+      fileStore:
+        size: 6Gi
+
+# OpenSearch — reduced resources for local development
+opensearch:
+  resources:
+    requests:
+      cpu: 500m
+      memory: 0.5Gi
+    limits:
+      cpu: 1000m
+      memory: 1Gi
+
+# OpenFGA — reduced resources for local development
+openfga:
+  resources:
+    limits:
+      cpu: 1000m
+      memory: 256Mi
+    requests:
+      cpu: 500m
+      memory: 128Mi
+
+# Heimdall — reduced resources for local development
+heimdall:
+  deployment:
+    resources:
+      limits:
+        cpu: 100m
+        memory: 128Mi
+      requests:
+        cpu: 100m
+        memory: 128Mi

--- a/charts/lfx-platform/values-local.yaml
+++ b/charts/lfx-platform/values-local.yaml
@@ -8,18 +8,22 @@
 #
 #   helm install -n lfx lfx-platform \
 #     oci://ghcr.io/linuxfoundation/lfx-v2-helm/chart/lfx-platform \
-#     --version <version> \
-#     --values values-local.yaml
+#     --values https://raw.githubusercontent.com/linuxfoundation/lfx-v2-helm/main/charts/lfx-platform/values-local.yaml
 #
 # Or from source:
 #
 #   helm install -n lfx lfx-platform ./charts/lfx-platform \
 #     --values charts/lfx-platform/values-local.yaml
 
-# NATS configuration — reduced resources for local development
+# NATS — reduced resources and single replica for local development
 # Production defaults require ~24Gi memory (3 replicas × 8Gi limit).
-# These settings are suitable for local machines with limited RAM.
 nats:
+  config:
+    cluster:
+      replicas: 3
+    jetstream:
+      fileStore:
+        size: 6Gi
   container:
     env:
       # Should be ~80% of the memory limit below
@@ -32,10 +36,6 @@ nats:
         limits:
           cpu: "1000m"
           memory: 2Gi
-  config:
-    jetstream:
-      fileStore:
-        size: 6Gi
 
 # OpenSearch — reduced resources for local development
 opensearch:
@@ -47,19 +47,21 @@ opensearch:
       cpu: 1000m
       memory: 1Gi
 
-# OpenFGA — reduced resources for local development
+# OpenFGA — single replica and reduced resources for local development
 openfga:
+  replicaCount: 1
   resources:
     limits:
       cpu: 1000m
-      memory: 256Mi
+      memory: 512Mi
     requests:
       cpu: 500m
-      memory: 128Mi
+      memory: 256Mi
 
-# Heimdall — reduced resources for local development
+# Heimdall — single replica and reduced resources for local development
 heimdall:
   deployment:
+    replicaCount: 1
     resources:
       limits:
         cpu: 100m
@@ -67,3 +69,33 @@ heimdall:
       requests:
         cpu: 100m
         memory: 128Mi
+
+# LFX services — single replica for local development
+lfx-v2-access-check:
+  replicaCount: 1
+lfx-v2-auth-service:
+  replicaCount: 1
+lfx-v2-committee-service:
+  replicaCount: 1
+lfx-v2-fga-sync:
+  replicaCount: 1
+lfx-v2-indexer-service:
+  replicaCount: 1
+lfx-v2-mailing-list-service:
+  replicaCount: 1
+  externalSecretsOperator:
+    enabled: false
+lfx-v2-meeting-service:
+  replicaCount: 1
+lfx-v2-project-service:
+  replicaCount: 1
+lfx-v2-query-service:
+  replicaCount: 1
+lfx-v2-survey-service:
+  replicaCount: 1
+  externalSecretsOperator:
+    enabled: false
+lfx-v2-voting-service:
+  replicaCount: 1
+  externalSecretsOperator:
+    enabled: false

--- a/charts/lfx-platform/values-local.yaml
+++ b/charts/lfx-platform/values-local.yaml
@@ -15,18 +15,15 @@
 #   helm install -n lfx lfx-platform ./charts/lfx-platform \
 #     --values charts/lfx-platform/values-local.yaml
 
-# NATS — reduced resources and single replica for local development
+# NATS — reduced resources for local development
 # Production defaults require ~24Gi memory (3 replicas × 8Gi limit).
 nats:
   config:
     cluster:
       replicas: 3
-    jetstream:
-      fileStore:
-        size: 6Gi
+
   container:
     env:
-      # Should be ~80% of the memory limit below
       GOMEMLIMIT: 2GiB
     merge:
       resources:

--- a/charts/lfx-platform/values.local.example.yaml
+++ b/charts/lfx-platform/values.local.example.yaml
@@ -3,20 +3,21 @@
 ---
 # Local development overrides for lfx-platform.
 #
-# Use this file when installing the chart on a local machine to reduce
-# resource requirements. Pass it alongside the chart install:
+# To use this file, copy it to values.local.yaml and fill in the values
+# you want to override.
+#
+# To use the file to install the GHCR chart, run the following command:
 #
 #   helm install -n lfx lfx-platform \
 #     oci://ghcr.io/linuxfoundation/lfx-v2-helm/chart/lfx-platform \
-#     --values https://raw.githubusercontent.com/linuxfoundation/lfx-v2-helm/main/charts/lfx-platform/values-local.yaml
+#     --values charts/lfx-platform/values.local.yaml
 #
 # Or from source:
 #
 #   helm install -n lfx lfx-platform ./charts/lfx-platform \
-#     --values charts/lfx-platform/values-local.yaml
+#     --values charts/lfx-platform/values.local.yaml
 
-# NATS — reduced resources for local development
-# Production defaults require ~24Gi memory (3 replicas × 8Gi limit).
+# NATS
 nats:
   config:
     cluster:
@@ -34,7 +35,7 @@ nats:
           cpu: "1000m"
           memory: 2Gi
 
-# OpenSearch — reduced resources for local development
+# OpenSearch
 opensearch:
   resources:
     requests:
@@ -44,7 +45,7 @@ opensearch:
       cpu: 1000m
       memory: 1Gi
 
-# OpenFGA — single replica and reduced resources for local development
+# OpenFGA
 openfga:
   replicaCount: 1
   resources:
@@ -55,7 +56,7 @@ openfga:
       cpu: 500m
       memory: 256Mi
 
-# Heimdall — single replica and reduced resources for local development
+# Heimdall
 heimdall:
   deployment:
     replicaCount: 1
@@ -67,7 +68,7 @@ heimdall:
         cpu: 100m
         memory: 128Mi
 
-# LFX services — single replica for local development
+# LFX services
 lfx-v2-access-check:
   replicaCount: 1
 lfx-v2-auth-service:

--- a/charts/lfx-platform/values.yaml
+++ b/charts/lfx-platform/values.yaml
@@ -567,7 +567,7 @@ nack:
     additionalArgs: [--control-loop]
 
 external-secrets:
-  enabled: true
+  enabled: false
   installCRDs: true
 
 cert-manager:

--- a/charts/lfx-platform/values.yaml
+++ b/charts/lfx-platform/values.yaml
@@ -154,15 +154,15 @@ openfga:
       sampleRatio: 1.0
 
   # Additional OpenFGA configuration
-  replicaCount: 3
+  replicaCount: 1
 
   resources:
     limits:
       cpu: 1000m
-      memory: 1024Mi
+      memory: 512Mi
     requests:
       cpu: 500m
-      memory: 512Mi
+      memory: 256Mi
 # Heimdall configuration
 heimdall:
   enabled: true
@@ -172,14 +172,14 @@ heimdall:
 
 
   deployment:
-    replicaCount: 3
+    replicaCount: 1
     resources:
       limits:
         cpu: 100m
-        memory: 256Mi
+        memory: 128Mi
       requests:
         cpu: 100m
-        memory: 256Mi
+        memory: 128Mi
     autoscaling:
       enabled: false
     labels:
@@ -358,16 +358,16 @@ nats:
     env:
       # Different from k8s units, suffix must be B, KiB, MiB, GiB, or TiB
       # Should be ~80% of memory limit
-      GOMEMLIMIT: 6GiB
+      GOMEMLIMIT: 2GiB
     merge:
       # Recommended minimum: at least 2 CPU cores and 8Gi memory for production JetStream clusters
       resources:
         requests:
-          cpu: "1000m"
-          memory: 4Gi
+          cpu: "500m"
+          memory: 1Gi
         limits:
-          cpu: "2000m"
-          memory: 8Gi
+          cpu: "1000m"
+          memory: 2Gi
 
 # OpenSearch configuration
 opensearch:
@@ -380,11 +380,11 @@ opensearch:
       value: "true"
   resources:
     requests:
-      cpu: 1000m
-      memory: 8Gi
+      cpu: 500m
+      memory: 0.5Gi
     limits:
-      cpu: 2000m
-      memory: 16Gi
+      cpu: 1000m
+      memory: 1Gi
 
 # Mailpit configuration
 mailpit:
@@ -577,21 +577,25 @@ trust-manager:
   namespace: cert-manager
 
 lfx-v2-fga-sync:
+  replicaCount: 1
   enabled: true
   lfx:
     domain: k8s.orb.local
 
 lfx-v2-access-check:
+  replicaCount: 1
   enabled: true
   lfx:
     domain: k8s.orb.local
 
 lfx-v2-indexer-service:
+  replicaCount: 1
   enabled: true
   lfx:
     domain: k8s.orb.local
 
 lfx-v2-query-service:
+  replicaCount: 1
   enabled: true
   lfx:
     domain: k8s.orb.local
@@ -610,48 +614,75 @@ lfx-v2-query-service:
         value: ""
 
 lfx-v2-project-service:
+  replicaCount: 1
   enabled: true
   lfx:
     domain: k8s.orb.local
 
 lfx-v2-committee-service:
+  replicaCount: 1
   enabled: true
   lfx:
     domain: k8s.orb.local
 
 lfx-v2-voting-service:
-  enabled: true
+  replicaCount: 1
+  enabled: false
   lfx:
     domain: k8s.orb.local
+
+  # External Secrets Operator is disabled because we can't get secrets from AWS Secrets Manager in local development.
+  # Instead, create the Kubernetes secret manually. See the chart README for instructions.
+  externalSecretsOperator:
+    enabled: false
 
   # Enable reloader to restart pods when ConfigMap or Secrets change
   annotations:
     reloader.stakater.com/auto: "true"
 
 lfx-v2-survey-service:
-  enabled: true
+  replicaCount: 1
+  enabled: false
   lfx:
     domain: k8s.orb.local
+
+  # External Secrets Operator is disabled because we can't get secrets from AWS Secrets Manager in local development.
+  # Instead, create the Kubernetes secret manually. See the chart README for instructions.
+  externalSecretsOperator:
+    enabled: false
 
   # Enable reloader to restart pods when ConfigMap or Secrets change
   annotations:
     reloader.stakater.com/auto: "true"
 
 lfx-v2-meeting-service:
-  enabled: true
+  replicaCount: 1
+  enabled: false
   lfx:
     domain: k8s.orb.local
+
+  # External Secrets Operator is disabled because we can't get secrets from AWS Secrets Manager in local development.
+  # Instead, create the Kubernetes secret manually. See the chart README for instructions.
+  externalSecretsOperator:
+    enabled: false
 
   # Enable reloader to restart pods when ConfigMap or Secrets change
   annotations:
     reloader.stakater.com/auto: "true"
 
 lfx-v2-mailing-list-service:
-  enabled: true
+  replicaCount: 1
+  enabled: false
   lfx:
     domain: k8s.orb.local
 
+  # External Secrets Operator is disabled because we can't get secrets from AWS Secrets Manager in local development.
+  # Instead, create the Kubernetes secret manually. See the chart README for instructions.
+  externalSecretsOperator:
+    enabled: false
+
 lfx-v2-auth-service:
+  replicaCount: 1
   enabled: true
   lfx:
     domain: k8s.orb.local

--- a/charts/lfx-platform/values.yaml
+++ b/charts/lfx-platform/values.yaml
@@ -566,6 +566,10 @@ nack:
       url: nats://lfx-platform-nats:4222
     additionalArgs: [--control-loop]
 
+external-secrets:
+  enabled: true
+  installCRDs: true
+
 cert-manager:
   enabled: false
   crds:
@@ -627,7 +631,7 @@ lfx-v2-committee-service:
 
 lfx-v2-voting-service:
   replicaCount: 1
-  enabled: false
+  enabled: true
   lfx:
     domain: k8s.orb.local
 
@@ -642,7 +646,7 @@ lfx-v2-voting-service:
 
 lfx-v2-survey-service:
   replicaCount: 1
-  enabled: false
+  enabled: true
   lfx:
     domain: k8s.orb.local
 
@@ -657,7 +661,7 @@ lfx-v2-survey-service:
 
 lfx-v2-meeting-service:
   replicaCount: 1
-  enabled: false
+  enabled: true
   lfx:
     domain: k8s.orb.local
 
@@ -672,7 +676,7 @@ lfx-v2-meeting-service:
 
 lfx-v2-mailing-list-service:
   replicaCount: 1
-  enabled: false
+  enabled: true
   lfx:
     domain: k8s.orb.local
 


### PR DESCRIPTION
## Summary

Adds a `values-local.yaml` file to the chart for local development installs, reducing resource requirements and disabling components that require AWS infrastructure unavailable outside of EKS. Also updates subchart dependency versions that were out of date.

## Changes

### `values-local.yaml` — local development overrides

Added a tracked `values-local.yaml` that ships with the chart package. This file reduces resource limits and replica counts to make the chart installable on a local machine with limited RAM.

The default `values.yaml` is production-grade and requires significant memory — for example, NATS alone requests ~12Gi across 3 replicas with 8Gi limits each. On a local machine this causes pods to get stuck in `Pending` with `Insufficient memory`. The local overrides bring this down to a manageable footprint:

| Component | Production memory limit | Local memory limit |
|-----------|------------------------|-------------------|
| NATS (per replica) | 8Gi | 2Gi |
| OpenSearch | 16Gi | 1Gi |
| OpenFGA | 1Gi × 3 replicas | 512Mi × 1 replica |
| Heimdall | 256Mi × 3 replicas | 128Mi × 1 replica |
| All LFX services | 3 replicas | 1 replica |

### `README.md` — local development installation instructions

Updated the OCI registry install section to omit `--version` so the latest chart version is always used, and added a local development subsection with install commands using `values-local.yaml` — both via raw GitHub URL (no clone needed) and from a local file path.

### ExternalSecrets Operator disabled for local installs

Three services use AWS Secrets Manager via IRSA (IAM Roles for Service Accounts) — `lfx-v2-voting-service`, `lfx-v2-survey-service`, and `lfx-v2-mailing-list-service`. This auth path requires an EKS OIDC provider and an annotated IAM role on the service account, neither of which exist on a local k3s/OrbStack cluster. Without this override the SecretStores fail with `unable to create session: an IAM role must be associated with service account`. The local values file disables the operator for these services.

### `Chart.yaml` / `Chart.lock` — subchart dependency updates

Updated subchart dependency versions in `Chart.yaml` and regenerated `Chart.lock` to reflect versions that were out of date.

## Ticket

[LFXV2-1256](https://linuxfoundation.atlassian.net/browse/LFXV2-1256)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

[LFXV2-1256]: https://linuxfoundation.atlassian.net/browse/LFXV2-1256?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ