### PR TITLE
[LFXV2-1291] feat: add voting, survey, and missing API specs to swagger UI

### DIFF
--- a/charts/lfx-platform/Chart.lock
+++ b/charts/lfx-platform/Chart.lock
@@ -64,9 +64,9 @@ dependencies:
   version: 0.3.5
 - name: lfx-v2-voting-service
   repository: oci://ghcr.io/linuxfoundation/lfx-v2-voting-service/chart
-  version: 0.2.1
+  version: 0.2.2
 - name: lfx-v2-survey-service
   repository: oci://ghcr.io/linuxfoundation/lfx-v2-survey-service/chart
-  version: 0.2.1
-digest: sha256:71a05805933c50182d5d59dc397c1e32c8d908e9f53e318f6cc2ed6b805e1774
-generated: "2026-03-16T09:02:41.749722-07:00"
+  version: 0.2.2
+digest: sha256:f69fce26d519ff2eb1a363deb17d1464509b9ca1b2110771060506c8221c7f36
+generated: "2026-03-16T14:41:15.158926-07:00"

--- a/charts/lfx-platform/Chart.yaml
+++ b/charts/lfx-platform/Chart.yaml
@@ -95,9 +95,9 @@ dependencies:
     condition: lfx-v2-auth-service.enabled
   - name: lfx-v2-voting-service
     repository: oci://ghcr.io/linuxfoundation/lfx-v2-voting-service/chart
-    version: ~0.2.1
+    version: ~0.2.2
     condition: lfx-v2-voting-service.enabled
   - name: lfx-v2-survey-service
     repository: oci://ghcr.io/linuxfoundation/lfx-v2-survey-service/chart
-    version: ~0.2.1
+    version: ~0.2.2
     condition: lfx-v2-survey-service.enabled

--- a/charts/lfx-platform/values.yaml
+++ b/charts/lfx-platform/values.yaml
@@ -47,6 +47,11 @@ lfx:
     specs:
       - "_projects/openapi3.yaml"
       - "_query/openapi3.yaml"
+      - "_committees/openapi3.yaml"
+      - "_meetings/openapi3.yaml"
+      - "_access-check/openapi3.yaml"
+      - "_voting/openapi3.yaml"
+      - "_survey/openapi3.yaml"
 
   # Tells rulesets to use the oidc_contextualizer, needed for
   # local dev with authelia


### PR DESCRIPTION
## Summary

- Add `_voting/openapi3.yaml` and `_survey/openapi3.yaml` to the swagger UI specs list in local dev `values.yaml`
- Add `_committees/openapi3.yaml`, `_meetings/openapi3.yaml`, and `_access-check/openapi3.yaml` which were already in argocd environments but missing from the helm chart local dev values

## Ticket

[LFXV2-1291](https://linuxfoundation.atlassian.net/browse/LFXV2-1291)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

[LFXV2-1291]: https://linuxfoundation.atlassian.net/browse/LFXV2-1291?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ