### PR TITLE
[LFXV2-504] bump versions for auth, indexer, committee, mailing list, voting and survey services

### DIFF
--- a/charts/lfx-platform/Chart.lock
+++ b/charts/lfx-platform/Chart.lock
@@ -19,7 +19,7 @@ dependencies:
   version: 0.25.2
 - name: authelia
   repository: https://charts.authelia.com
-  version: 0.10.49
+  version: 0.10.50
 - name: nack
   repository: https://nats-io.github.io/k8s/helm/charts/
   version: 0.29.2
@@ -49,24 +49,24 @@ dependencies:
   version: 0.2.8
 - name: lfx-v2-indexer-service
   repository: oci://ghcr.io/linuxfoundation/lfx-v2-indexer-service/chart
-  version: 0.4.16
+  version: 0.4.17
 - name: lfx-v2-committee-service
   repository: oci://ghcr.io/linuxfoundation/lfx-v2-committee-service/chart
-  version: 0.2.21
+  version: 0.2.22
 - name: lfx-v2-meeting-service
   repository: oci://ghcr.io/linuxfoundation/lfx-v2-meeting-service/chart
   version: 0.7.0
 - name: lfx-v2-mailing-list-service
   repository: oci://ghcr.io/linuxfoundation/lfx-v2-mailing-list-service/chart
-  version: 0.2.0
+  version: 0.3.0
 - name: lfx-v2-auth-service
   repository: oci://ghcr.io/linuxfoundation/lfx-v2-auth-service/chart
-  version: 0.3.5
+  version: 0.4.0
 - name: lfx-v2-voting-service
   repository: oci://ghcr.io/linuxfoundation/lfx-v2-voting-service/chart
-  version: 0.2.2
+  version: 0.2.3
 - name: lfx-v2-survey-service
   repository: oci://ghcr.io/linuxfoundation/lfx-v2-survey-service/chart
-  version: 0.2.2
-digest: sha256:f69fce26d519ff2eb1a363deb17d1464509b9ca1b2110771060506c8221c7f36
-generated: "2026-03-16T14:41:15.158926-07:00"
+  version: 0.2.3
+digest: sha256:920bd36a873769cfc78925c339123a01fb744bf985239f2213bfe48047272764
+generated: "2026-03-18T10:55:55.919661-03:00"

--- a/charts/lfx-platform/Chart.lock
+++ b/charts/lfx-platform/Chart.lock
@@ -61,12 +61,12 @@ dependencies:
   version: 0.3.0
 - name: lfx-v2-auth-service
   repository: oci://ghcr.io/linuxfoundation/lfx-v2-auth-service/chart
-  version: 0.4.0
+  version: 0.4.1
 - name: lfx-v2-voting-service
   repository: oci://ghcr.io/linuxfoundation/lfx-v2-voting-service/chart
   version: 0.2.3
 - name: lfx-v2-survey-service
   repository: oci://ghcr.io/linuxfoundation/lfx-v2-survey-service/chart
   version: 0.2.3
-digest: sha256:920bd36a873769cfc78925c339123a01fb744bf985239f2213bfe48047272764
-generated: "2026-03-18T10:55:55.919661-03:00"
+digest: sha256:b0142fe2b2b7d98c54f03d515edf46a835ba17c6a3aebc491a5ee0d98d0b1e2f
+generated: "2026-03-18T13:20:19.36663-03:00"

--- a/charts/lfx-platform/Chart.yaml
+++ b/charts/lfx-platform/Chart.yaml
@@ -91,7 +91,7 @@ dependencies:
     condition: lfx-v2-mailing-list-service.enabled
   - name: lfx-v2-auth-service
     repository: oci://ghcr.io/linuxfoundation/lfx-v2-auth-service/chart
-    version: ~0.4.0
+    version: ~0.4.1
     condition: lfx-v2-auth-service.enabled
   - name: lfx-v2-voting-service
     repository: oci://ghcr.io/linuxfoundation/lfx-v2-voting-service/chart

--- a/charts/lfx-platform/Chart.yaml
+++ b/charts/lfx-platform/Chart.yaml
@@ -75,11 +75,11 @@ dependencies:
     condition: lfx-v2-access-check.enabled
   - name: lfx-v2-indexer-service
     repository: oci://ghcr.io/linuxfoundation/lfx-v2-indexer-service/chart
-    version: ~0.4.16
+    version: ~0.4.17
     condition: lfx-v2-indexer-service.enabled
   - name: lfx-v2-committee-service
     repository: oci://ghcr.io/linuxfoundation/lfx-v2-committee-service/chart
-    version: ~0.2.21
+    version: ~0.2.22
     condition: lfx-v2-committee-service.enabled
   - name: lfx-v2-meeting-service
     repository: oci://ghcr.io/linuxfoundation/lfx-v2-meeting-service/chart
@@ -87,17 +87,17 @@ dependencies:
     condition: lfx-v2-meeting-service.enabled
   - name: lfx-v2-mailing-list-service
     repository: oci://ghcr.io/linuxfoundation/lfx-v2-mailing-list-service/chart
-    version: ~0.2.0
+    version: ~0.3.0
     condition: lfx-v2-mailing-list-service.enabled
   - name: lfx-v2-auth-service
     repository: oci://ghcr.io/linuxfoundation/lfx-v2-auth-service/chart
-    version: ~0.3.5
+    version: ~0.4.0
     condition: lfx-v2-auth-service.enabled
   - name: lfx-v2-voting-service
     repository: oci://ghcr.io/linuxfoundation/lfx-v2-voting-service/chart
-    version: ~0.2.2
+    version: ~0.2.3
     condition: lfx-v2-voting-service.enabled
   - name: lfx-v2-survey-service
     repository: oci://ghcr.io/linuxfoundation/lfx-v2-survey-service/chart
-    version: ~0.2.2
+    version: ~0.2.3
     condition: lfx-v2-survey-service.enabled


### PR DESCRIPTION
## Overview

Jira Ticket: https://linuxfoundation.atlassian.net/browse/LFXV2-504

This pull request updates several service dependencies in the `charts/lfx-platform/Chart.yaml` file to newer versions. These updates help ensure that the platform is using the latest features and bug fixes from each service.

Dependency version updates:

* Upgraded `lfx-v2-indexer-service` chart version from `~0.4.16` to `~0.4.17`.
* Upgraded `lfx-v2-committee-service` chart version from `~0.2.21` to `~0.2.22`.
* Upgraded `lfx-v2-mailing-list-service` chart version from `~0.2.0` to `~0.3.0`.
* Upgraded `lfx-v2-auth-service` chart version from `~0.3.5` to `~0.4.0`.
* Upgraded `lfx-v2-voting-service` and `lfx-v2-survey-service` chart versions from `~0.2.2` to `~0.2.3`.