### PR TITLE
update chart dependencies

### DIFF
--- a/charts/lfx-platform/Chart.lock
+++ b/charts/lfx-platform/Chart.lock
@@ -4,10 +4,10 @@ dependencies:
   version: 36.2.0
 - name: openfga
   repository: https://openfga.github.io/helm-charts
-  version: 0.2.56
+  version: 0.2.57
 - name: heimdall
   repository: oci://ghcr.io/dadrus/heimdall/chart
-  version: 0.16.11
+  version: 0.16.12
 - name: nats
   repository: https://nats-io.github.io/k8s/helm/charts/
   version: 1.3.16
@@ -46,13 +46,13 @@ dependencies:
   version: 0.2.14
 - name: lfx-v2-access-check
   repository: oci://ghcr.io/linuxfoundation/lfx-v2-access-check/chart
-  version: 0.2.8
+  version: 0.2.9
 - name: lfx-v2-indexer-service
   repository: oci://ghcr.io/linuxfoundation/lfx-v2-indexer-service/chart
   version: 0.4.17
 - name: lfx-v2-committee-service
   repository: oci://ghcr.io/linuxfoundation/lfx-v2-committee-service/chart
-  version: 0.2.22
+  version: 0.2.23
 - name: lfx-v2-meeting-service
   repository: oci://ghcr.io/linuxfoundation/lfx-v2-meeting-service/chart
   version: 0.7.0
@@ -61,12 +61,12 @@ dependencies:
   version: 0.3.0
 - name: lfx-v2-auth-service
   repository: oci://ghcr.io/linuxfoundation/lfx-v2-auth-service/chart
-  version: 0.4.1
+  version: 0.4.2
 - name: lfx-v2-voting-service
   repository: oci://ghcr.io/linuxfoundation/lfx-v2-voting-service/chart
   version: 0.2.3
 - name: lfx-v2-survey-service
   repository: oci://ghcr.io/linuxfoundation/lfx-v2-survey-service/chart
   version: 0.2.3
-digest: sha256:b0142fe2b2b7d98c54f03d515edf46a835ba17c6a3aebc491a5ee0d98d0b1e2f
-generated: "2026-03-18T13:20:19.36663-03:00"
+digest: sha256:dd77811c089e306094279fe5034a3d9a0f46ea2bc221e15e5475b06c2e49889f
+generated: "2026-03-23T08:53:44.272856-07:00"

--- a/charts/lfx-platform/Chart.yaml
+++ b/charts/lfx-platform/Chart.yaml
@@ -71,7 +71,7 @@ dependencies:
     condition: lfx-v2-fga-sync.enabled
   - name: lfx-v2-access-check
     repository: oci://ghcr.io/linuxfoundation/lfx-v2-access-check/chart
-    version: ~0.2.8
+    version: ~0.2.9
     condition: lfx-v2-access-check.enabled
   - name: lfx-v2-indexer-service
     repository: oci://ghcr.io/linuxfoundation/lfx-v2-indexer-service/chart


### PR DESCRIPTION
Particularly for the lfx-v2-access-check v0.2.9 which fixes some documentation examples