### PR TITLE
feat(openfga): add b2b_org, project_membership, and key_contact types

### DIFF
--- a/PERMISSIONS.md
+++ b/PERMISSIONS.md
@@ -177,3 +177,41 @@ role assignment.
 - ***Auditor***: inherited from Project Auditor, Committee Auditor
 
 ---
+
+### B2B Organization
+
+Access to a B2B Organization object is controlled via three directly-assignable
+roles: **Owner**, **Writer**, and **Auditor**. No job-to-be-done actions are
+documented for this type yet; this section will be expanded as API coverage
+grows.
+
+#### Permission Inheritance
+
+- **Writer**: also granted to Owner; inherited from global org-admin team
+- **Auditor**: also granted to Writer
+
+---
+
+### Project Membership
+
+Access to a Project Membership object is fully inherited — there are no
+directly-assignable roles on this type. Write access is scoped to B2B
+Organization writers; read access is additionally available to Project auditors.
+
+#### Permission Inheritance
+
+- ***Writer***: inherited from B2B Organization Writer
+- ***Auditor***: inherited from B2B Organization Auditor, Project Auditor
+
+---
+
+### Key Contact
+
+Access to a Key Contact object is fully inherited — there are no
+directly-assignable roles on this type. Both write and read access are
+available to either the parent B2B Organization or the parent Project.
+
+#### Permission Inheritance
+
+- ***Writer***: inherited from B2B Organization Writer, Project Writer
+- ***Auditor***: inherited from B2B Organization Auditor, Project Auditor

--- a/charts/lfx-platform/templates/openfga/model.yaml
+++ b/charts/lfx-platform/templates/openfga/model.yaml
@@ -23,8 +23,8 @@ spec:
   @fgadoc:hide, @fgadoc:alias, @fgadoc:collapse tags are managed manually.
 */}}
     - version:
-        major: 10
-        minor: 1
+        major: 11
+        minor: 0
         patch: 0
       authorizationModel: |
         model

--- a/charts/lfx-platform/templates/openfga/model.yaml
+++ b/charts/lfx-platform/templates/openfga/model.yaml
@@ -419,10 +419,38 @@ spec:
             # we just use the "owner" relation in our access checks!
             define auditor: owner or auditor from survey
 
-        # @fgadoc:hide
-        # This type is used for access to membership apis, not to define someone as a project member
-        # eventually it needs to be expanded as we index objects
-        type member
+        # The b2b_org type represents a Salesforce Account (B2B company). The UID is
+        # an invertible UUID v8 encoded from the Salesforce Account SFID.
+        # global_org_admin is written to every b2b_org at creation time by the member
+        # service, providing writer (and transitively auditor) access to all org admins
+        # without requiring a hierarchical root object.
+        type b2b_org
           relations
-            define auditor: [user, team#member]
+            define global_org_admin: [team#member]
+            define owner: [user]
+            define writer: [user] or owner or global_org_admin
+            define auditor: [user, team#member] or writer
+
+        # The project_membership type represents a Salesforce Asset record: one active
+        # (or expired) membership term for a b2b_org within a project. Access is derived
+        # from the caller's relationship to the parent b2b_org or parent project.
+        # writer is intentionally scoped to b2b_org only: project-level writers (LF staff)
+        # can audit memberships but cannot create or modify them.
+        type project_membership
+          relations
+            define b2b_org: [b2b_org]
+            define project: [project]
+            define writer: writer from b2b_org
+            define auditor: auditor from b2b_org or auditor from project
+
+        # The key_contact type represents a Salesforce Project_Role__c record: a named
+        # contact role assigned to a b2b_org for a specific project membership. Write
+        # access is granted to b2b_org writers (owners and global org-admin team) and to
+        # project-level writers (LF staff managing contacts on behalf of members).
+        type key_contact
+          relations
+            define b2b_org: [b2b_org]
+            define project: [project]
+            define writer: writer from b2b_org or writer from project
+            define auditor: auditor from b2b_org or auditor from project
 {{- end }}

--- a/charts/lfx-platform/templates/openfga/model.yaml
+++ b/charts/lfx-platform/templates/openfga/model.yaml
@@ -419,6 +419,7 @@ spec:
             # we just use the "owner" relation in our access checks!
             define auditor: owner or auditor from survey
 
+        # @fgadoc:alias B2B Organization
         # The b2b_org type represents a Salesforce Account (B2B company). The UID is
         # an invertible UUID v8 encoded from the Salesforce Account SFID.
         # global_org_admin is written to every b2b_org at creation time by the member
@@ -426,11 +427,13 @@ spec:
         # without requiring a hierarchical root object.
         type b2b_org
           relations
+            # @fgadoc:hide
             define global_org_admin: [team#member]
             define owner: [user]
             define writer: [user] or owner or global_org_admin
             define auditor: [user, team#member] or writer
 
+        # @fgadoc:alias Project Membership
         # The project_membership type represents a Salesforce Asset record: one active
         # (or expired) membership term for a b2b_org within a project. Access is derived
         # from the caller's relationship to the parent b2b_org or parent project.
@@ -443,6 +446,7 @@ spec:
             define writer: writer from b2b_org
             define auditor: auditor from b2b_org or auditor from project
 
+        # @fgadoc:alias Key Contact
         # The key_contact type represents a Salesforce Project_Role__c record: a named
         # contact role assigned to a b2b_org for a specific project membership. Write
         # access is granted to b2b_org writers (owners and global org-admin team) and to


### PR DESCRIPTION
## Summary

- Add `b2b_org`, `project_membership`, and `key_contact` OpenFGA types for the v2 member service architecture
- Replace the unused stub `member` type with these three first-class types
- Bump model version to 11.0.0 (major — type additions/deletions per in-file guidelines)
- Add `@fgadoc` structural annotations to all three new types
- Extend `PERMISSIONS.md` via the `render-permissions` skill with sections for each new type

## Jira

[LFXV2-1356](https://linuxfoundation.atlassian.net/browse/LFXV2-1356) — part of epic [LFXV2-1344](https://linuxfoundation.atlassian.net/browse/LFXV2-1344)

## Changes

**`b2b_org`** — represents a Salesforce Account (B2B company):
- `global_org_admin: [team#member]` — platform-wide machine user team stamped on every instance at creation (`@fgadoc:hide` — not directly assignable by humans)
- `owner: [user]` — human owners only; reserved for future owner-only gates (transfer, deletion)
- `writer: [user] or owner or global_org_admin` — machine users get writer-level access (not owner)
- `auditor: [user, team#member] or writer`

**`project_membership`** — Salesforce Asset record with parent refs to `b2b_org` and `project`:
- `writer` inherits from `b2b_org` only (org owners + global org-admin team); project-level writers can audit but not modify memberships
- `auditor` inherits from both `b2b_org` and `project`

**`key_contact`** — Salesforce `Project_Role__c` record, same parent refs:
- `writer` inherits from both `b2b_org` (org owners + global org-admin) and `project` (LF staff managing contacts on behalf of members)
- `auditor` inherits from both `b2b_org` and `project`

## PERMISSIONS.md

`b2b_org` renders as a prose section (direct-grant roles exist but no `@fgadoc:jtbd` yet — API routes not yet implemented; will be populated by the `populate-jtbds` skill once LFXV2-1360–1362 land). `project_membership` and `key_contact` render as prose-only inheritance sections since all access is inherited.

## Testing

Existing FGA checks (`project` auditor/writer) are unaffected. New types will be exercised when the member service write handlers are implemented (LFXV2-1360–1362).

[LFXV2-1356]: https://linuxfoundation.atlassian.net/browse/LFXV2-1356?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LFXV2-1344]: https://linuxfoundation.atlassian.net/browse/LFXV2-1344?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ