### PR TITLE
fix: set missing resource requests/limits on lfx-platform chart components

### DIFF
--- a/charts/lfx-platform/templates/whoami/deployment.yaml
+++ b/charts/lfx-platform/templates/whoami/deployment.yaml
@@ -26,4 +26,5 @@ spec:
           ports:
             - name: web
               containerPort: 80
+          resources: {{- toYaml .Values.lfx.whoami.resources | nindent 12 }}
 {{- end }}

--- a/charts/lfx-platform/values.yaml
+++ b/charts/lfx-platform/values.yaml
@@ -396,14 +396,13 @@ nats:
           memory: 2Gi
   natsBox:
     container:
-      merge:
-        resources:
-          requests:
-            cpu: "1m"
-            memory: "4Mi"
-          limits:
-            cpu: "10m"
-            memory: "16Mi"
+      resources:
+        requests:
+          cpu: "1m"
+          memory: "4Mi"
+        limits:
+          cpu: "10m"
+          memory: "16Mi"
 
 # OpenSearch configuration
 opensearch:

--- a/charts/lfx-platform/values.yaml
+++ b/charts/lfx-platform/values.yaml
@@ -30,6 +30,13 @@ lfx:
 
   whoami:
     enabled: true
+    resources:
+      requests:
+        cpu: "1m"
+        memory: "4Mi"
+      limits:
+        cpu: "10m"
+        memory: "8Mi"
 
   swagger_ui:
     enabled: true
@@ -157,6 +164,16 @@ openfga:
         tls:
           enabled: false
       sampleRatio: 1.0
+
+  # Migration init container resources
+  migrations:
+    resources:
+      requests:
+        cpu: "50m"
+        memory: "64Mi"
+      limits:
+        cpu: "200m"
+        memory: "128Mi"
 
   # Additional OpenFGA configuration
   replicaCount: 1
@@ -377,6 +394,16 @@ nats:
         limits:
           cpu: "1000m"
           memory: 2Gi
+  natsBox:
+    container:
+      merge:
+        resources:
+          requests:
+            cpu: "1m"
+            memory: "4Mi"
+          limits:
+            cpu: "10m"
+            memory: "16Mi"
 
 # OpenSearch configuration
 opensearch:
@@ -574,6 +601,13 @@ nack:
     nats:
       url: nats://lfx-platform-nats:4222
     additionalArgs: [--control-loop]
+  resources:
+    requests:
+      cpu: "5m"
+      memory: "20Mi"
+    limits:
+      cpu: "50m"
+      memory: "32Mi"
 
 external-secrets:
   enabled: false
@@ -588,6 +622,21 @@ trust-manager:
   crds:
     enabled: true
   namespace: cert-manager
+  resources:
+    requests:
+      cpu: "5m"
+      memory: "24Mi"
+    limits:
+      cpu: "50m"
+      memory: "64Mi"
+  defaultPackageImage:
+    resources:
+      requests:
+        cpu: "10m"
+        memory: "16Mi"
+      limits:
+        cpu: "50m"
+        memory: "32Mi"
 
 lfx-v2-fga-sync:
   replicaCount: 1


### PR DESCRIPTION
Values based on 7-day Datadog prod metrics (avg/peak):
- trust-manager: 5m/50m CPU, 24Mi/64Mi mem (avg ~2m CPU, ~20Mi mem)
- trust-manager init (cert-manager-package-debian): 10m/50m CPU, 16Mi/32Mi mem (estimated, init container)
- nack (jsc): 5m/50m CPU, 20Mi/32Mi mem (avg ~2m CPU, ~17Mi mem)
- nats-box: 1m/10m CPU, 4Mi/16Mi mem (runs sleep infinity, ~0 CPU, ~0.4Mi mem)
- openfga migrate-database init: 50m/200m CPU, 64Mi/128Mi mem (estimated, init container)
- whoami: 1m/10m CPU, 4Mi/8Mi mem (avg ~0.001m CPU, ~1.2Mi mem); wire resources into deployment template