### PR TITLE
feat: add resource requests and limits to whoami deployment

### DIFF
--- a/charts/lfx-platform/templates/whoami/deployment.yaml
+++ b/charts/lfx-platform/templates/whoami/deployment.yaml
@@ -26,4 +26,8 @@ spec:
           ports:
             - name: web
               containerPort: 80
+          {{- with .Values.lfx.whoami.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
 {{- end }}

--- a/charts/lfx-platform/values.yaml
+++ b/charts/lfx-platform/values.yaml
@@ -30,6 +30,13 @@ lfx:
 
   whoami:
     enabled: true
+    resources:
+      requests:
+        cpu: "1m"
+        memory: "4Mi"
+      limits:
+        cpu: "10m"
+        memory: "8Mi"
 
   swagger_ui:
     enabled: true


### PR DESCRIPTION
## Summary
- Adds Kubernetes resource `requests` and `limits` to the whoami deployment template
- Exposes configuration via `values.yaml` with small defaults (1m/4Mi requests, 10m/8Mi limits)
- Backwards compatible — resources block is optional via `{{- with }}` guard

## Test plan
- [ ] `helm template` renders correctly with default values
- [ ] `helm template` renders correctly with overridden resource values
- [ ] `helm template` renders correctly when `whoami.resources` is omitted (backwards compat)

Issue: LFXV2-1385

🤖 Generated with [Claude Code](https://claude.com/claude-code)