### PR TITLE
fix(openfga): fix confirmed model bugs from LFXV2-1431 audit

### DIFF
--- a/PERMISSIONS.md
+++ b/PERMISSIONS.md
@@ -26,8 +26,8 @@ role assignment.
 
 | | Writer | Auditor | Meeting Coordinator | *Everyone* |
 |---|---|---|---|---|
-| View a project | ✅ | ✅ | | 🟡 |
-| View project meeting count | ✅ | ✅ | | 🟡 |
+| View a project | ✅ | ✅ | ✅ | 🟡 |
+| View project meeting count | ✅ | ✅ | ✅ | 🟡 |
 | View project settings | ✅ | ✅ | | |
 | View project membership tiers | ✅ | ✅ | | |
 | View project memberships & member companies | ✅ | ✅ | | |
@@ -36,7 +36,8 @@ role assignment.
 | Update project settings | ✅ | | | |
 | Create & update a project | ✅ | | | |
 | Create a vote | ✅ | | | |
-| Create project committees, meetings & mailing lists | ✅ | | | |
+| Create project committees & mailing lists | ✅ | | | |
+| Create project meetings | ✅ | | ✅ | |
 
 #### Permission Inheritance
 
@@ -49,8 +50,8 @@ role assignment.
 
 | | Writer | Auditor | Member | *Everyone* |
 |---|---|---|---|---|
-| View committee details, members, invites & resources | | ✅ | ✅ | 🟡 |
-| View committee settings | | ✅ | | |
+| View committee details, members, invites & resources | ✅ | ✅ | ✅ | 🟡 |
+| View committee settings | ✅ | ✅ | | |
 | Update committee settings | ✅ | | | |
 | Manage committee members, invites & applications | ✅ | | | |
 | Manage committee links & folders | ✅ | | | |
@@ -68,7 +69,7 @@ role assignment.
 
 | | Writer | Auditor | *Everyone* |
 |---|---|---|---|
-| View a Groups.io service | | | 🟡 |
+| View a Groups.io service | ✅ | ✅ | 🟡 |
 | Update & delete a Groups.io service | ✅ | | |
 | Create project mailing lists | ✅ | | |
 
@@ -83,8 +84,8 @@ role assignment.
 
 | | Writer | Auditor | Subscriber | *Everyone* |
 |---|---|---|---|---|
-| View a mailing list & its members | | | | 🟡 |
-| View & download mailing list artifacts | | | | 🟡 |
+| View a mailing list & its members | ✅ | ✅ | ✅ | 🟡 |
+| View & download mailing list artifacts | ✅ | ✅ | ✅ | 🟡 |
 | Add & remove mailing list members | ✅ | | | |
 | Update & delete a mailing list | ✅ | | | |
 
@@ -118,7 +119,7 @@ role assignment.
 
 | | *Organizer* | *Auditor* | Host | Invitee | Attendee | *Everyone* |
 |---|---|---|---|---|---|---|
-| View a past meeting & its attachments | ✅ | ✅ | | ✅ | ✅ | 🟡 |
+| View a past meeting & its attachments | ✅ | ✅ | ✅ | ✅ | ✅ | 🟡 |
 | View a past meeting summary | ✅ | ✅ | 🟡 | 🟡 | 🟡 | 🟡 |
 | Update a past meeting summary | ✅ | ✅ | | | | |
 | Manage past meeting participants & attachments | ✅ | | | | | |

--- a/charts/lfx-platform/templates/openfga/model.yaml
+++ b/charts/lfx-platform/templates/openfga/model.yaml
@@ -24,7 +24,7 @@ spec:
 */}}
     - version:
         major: 10
-        minor: 0
+        minor: 1
         patch: 0
       authorizationModel: |
         model
@@ -51,7 +51,7 @@ spec:
             define owner: [team#member] or owner from parent
             # @fgadoc:jtbd Create & update a project
             # @fgadoc:jtbd Update project settings
-            # @fgadoc:jtbd Create project committees, meetings & mailing lists
+            # @fgadoc:jtbd Create project committees & mailing lists
             # @fgadoc:jtbd Manage project membership key contacts
             # @fgadoc:jtbd Create a vote
             define writer: [user] or owner or writer from parent
@@ -61,9 +61,11 @@ spec:
             # @fgadoc:jtbd View project membership key contacts
             define auditor: [user, team#member] or writer or auditor from parent
             define meeting_coordinator: [user]
+            # @fgadoc:jtbd Create project meetings
+            define meetings_creator: writer or meeting_coordinator
             # @fgadoc:jtbd View a project
             # @fgadoc:jtbd View project meeting count
-            define viewer: [user:*] or auditor or auditor from parent
+            define viewer: [user:*] or auditor or meeting_coordinator
 
         type committee
           relations
@@ -76,23 +78,20 @@ spec:
             # @fgadoc:jtbd Schedule a survey for a committee
             define writer: [user] or writer from project
             # @fgadoc:jtbd View committee settings
-            define auditor: [user, team#member] or auditor from project or meeting_coordinator from project
+            define auditor: [user, team#member] or writer or auditor from project or meeting_coordinator from project
             # @fgadoc:jtbd View committee details, members, invites & resources
-            define viewer: [user:*] or member or auditor or auditor from project
+            define viewer: [user:*] or member or auditor
 
         # @fgadoc:alias Groups.io Service
         type groupsio_service
           relations
             define project: [project]
-            # Hiding `owner` because it has no JTBDs, and project `owner` relation is also hidden.
-            # @fgadoc:hide
-            define owner: [user] or owner from project
             # @fgadoc:jtbd Update & delete a Groups.io service
             # @fgadoc:jtbd Create project mailing lists
-            define writer: [user] or writer from project or owner
+            define writer: [user] or writer from project
             define auditor: [user] or auditor from project or writer
             # @fgadoc:jtbd View a Groups.io service
-            define viewer: [user:*] or auditor from project
+            define viewer: [user:*] or auditor
 
         # @fgadoc:alias Mailing List
         type groupsio_mailing_list
@@ -100,14 +99,13 @@ spec:
             define groupsio_service: [groupsio_service]  # Parent relationship
             define project: project from groupsio_service # Inherit project permissions
             define committee: [committee] # Inherit committee permissions
-            define owner: owner from groupsio_service
             # @fgadoc:jtbd Update & delete a mailing list
             # @fgadoc:jtbd Add & remove mailing list members
             define writer: [user] or writer from groupsio_service or writer from committee
             define auditor: [user] or auditor from groupsio_service or auditor from committee
             # @fgadoc:jtbd View a mailing list & its members
             # @fgadoc:jtbd View & download mailing list artifacts
-            define viewer: [user:*] or viewer from groupsio_service or member from committee
+            define viewer: [user:*] or writer or auditor or member
             # @fgadoc:alias Subscriber
             define member: [user]
 
@@ -175,7 +173,7 @@ spec:
             # The viewer relation identifies a user who can view this past meeting.
             # If the past meeting is public, then any user can view it; but if it is private, then
             # only certain privileged users can view it.
-            define viewer: [user:*] or attendee or invitee or organizer or auditor
+            define viewer: [user:*] or attendee or invitee or host or organizer or auditor
 
         # // Hide this from PERMISSIONS.md until we fold v1_meeting into meeting.
         # @fgadoc:hide
@@ -302,7 +300,7 @@ spec:
             define invitee: [user]
             define attendee: [user]
             # @fgadoc:jtbd View a past meeting & its attachments
-            define viewer: [user:*] or attendee or invitee or organizer or auditor
+            define viewer: [user:*] or attendee or invitee or host or organizer or auditor
 
         # *All relations are as described in `past_meeting_recording`, unless
         # otherwise noted.*


### PR DESCRIPTION
## Summary

- Fix 11 confirmed OpenFGA model bugs identified during the PERMISSIONS.md audit (LFXV2-1431)
- Bump model version to `10.1.0` (new `meetings_creator` relation added to `project`)
- Regenerate `PERMISSIONS.md` to reflect all changes, including the as-if JTBD for `meetings_creator`

## Changes

### Project
- **Bug 1**: Add `meeting_coordinator` to `viewer` chain — meeting coordinators can now view private projects for UI navigation
- **Bug 2**: Add `meetings_creator` relation (`writer or meeting_coordinator`) — enables meeting coordinators to create meetings without granting full `writer` access
- **Bug 14**: Remove redundant `auditor from parent` from `viewer` — already implied by `auditor`'s own definition

### Committee
- **Bug 3**: Add `writer` to `auditor` chain — `committee#writer` can now view the committee (was broken: write access without read access)
- **Bug 15**: Remove redundant `auditor from project` from `viewer` — already implied by `auditor`'s own definition

### Groups.io Service
- **Bug 5**: Remove dead `owner` relation — no service ever writes `groupsio_service#owner` tuples; `owner from project` path was already covered by `writer from project`
- **Bug 6**: Add local `auditor` to `viewer` — directly-granted `groupsio_service#auditor` can now view the service

### Past Meeting (`past_meeting` + `v1_past_meeting`)
- **Bug 7**: Add `host` to `viewer` chain — a host who is not the organizer can now view the past meeting

### Mailing List (`groupsio_mailing_list`)
- **Bug 10**: Add `writer` and `auditor` to `viewer` — writers/auditors can now view mailing lists
- **Bug 11**: Remove `viewer from groupsio_service` from `viewer` — service-level visibility no longer cascades to every list, fixing broken public/private list distinction
- **Bug 12**: Wire `member` (subscriber) into `viewer` — subscribers can now view the list they're subscribed to
- **Bug 13**: Remove `member from committee` from `viewer` — committee membership is not the same as list subscription; cross-type grants into `viewer` are also invisible to PERMISSIONS.md
- Remove dead `owner` relation (consequence of removing `owner` from `groupsio_service`)

## Out of scope (deferred)
- **Bug 4** (committee) / **Bug 8** (mailing list): Splitting `viewer` into granular scopes (details, roster, emails) — product-level design gap; see LFXV2-1476 and LFXV2-1477
- **Bug 9**: No action — confirmed active direct-user grants in mailing list service v1 sync handlers

## Companion PR
[lfx-v2-meeting-service#142](https://github.com/linuxfoundation/lfx-v2-meeting-service/pull/142) — updates the meeting service RuleSet to check `meetings_creator` (instead of `writer`) on `POST /itx/meetings` and `POST /itx/past_meetings`. That PR depends on this one landing first.

## Notes
- `PERMISSIONS.md` has been regenerated and includes the `meetings_creator` JTBD row ("Create project meetings" — Writer ✅, Meeting Coordinator ✅) as-is, without waiting for a live `populate-jtbds` run. The `meetings_creator` relation is a same-type union (`writer or meeting_coordinator`) with no cross-type terms, so its reachability in PERMISSIONS.md is fully deterministic from the model alone.

Jira: [LFXV2-1431](https://linuxfoundation.atlassian.net/browse/LFXV2-1431)

🤖 Generated with [GitHub Copilot](https://github.com/features/copilot) (via OpenCode)

[LFXV2-1431]: https://linuxfoundation.atlassian.net/browse/LFXV2-1431?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ