### PR TITLE
feat(skills): extend populate-jtbds to cover Query Service authorization

### DIFF
--- a/.agents/skills/populate-jtbds/SKILL.md
+++ b/.agents/skills/populate-jtbds/SKILL.md
@@ -33,8 +33,10 @@ the JTBD annotations need to be refreshed from real API usage.
   `v1_past_meeting`). These relations will have zero RuleSet entries; their
   JTBDs are synthesized from indexer contracts in Step 2b.
 - An indexed object type may not appear in `model.yaml` at all (e.g.,
-  `v1_meeting_registrant`). Step 2b writes JTBDs onto the `access_check_object`
-  type's relation in `model.yaml`, **not** onto the indexed type itself.
+  `v1_meeting_registrant`). Step 2b writes JTBDs onto the **delegate type**'s
+  relation in `model.yaml` — that is, the `access_check_object` value with any
+  `:<id>` suffix stripped (e.g. `v1_past_meeting:{meeting_and_occurrence_id}` →
+  `v1_past_meeting`) — **not** onto the indexed type itself.
 
 ## Discipline rules — read before synthesizing any JTBD
 
@@ -133,7 +135,7 @@ by the Query Service rather than Heimdall.
 
 **Search for all contracts:**
 
-```
+```text
 filename:indexer-contract.md org:linuxfoundation
 ```
 
@@ -146,8 +148,8 @@ batch (use the `repo` and `path` from each search result).
 - `access_check_object` — from the `Access Control (IndexingConfig)` table row
 - `access_check_relation` — from the same table
 
-Strip the `:{...}` suffix from `access_check_object` to get the **delegate
-type** (e.g., `v1_past_meeting:{meeting_and_occurrence_id}` →
+Strip everything after the first `:` from `access_check_object` to get the
+**delegate type** (e.g., `v1_past_meeting:{meeting_and_occurrence_id}` →
 `v1_past_meeting`).
 
 A resource type contributes a Query Service entry when its `access_check_object`
@@ -160,11 +162,11 @@ Write `/tmp/query_service_groups.json` in this shape:
 {
   "v1_past_meeting#viewer": [
     {
-      "indexed_type": "v1_past_meeting_recording",
+      "object_type": "v1_past_meeting_recording",
       "human_label": "past meeting recordings"
     },
     {
-      "indexed_type": "v1_past_meeting_transcript",
+      "object_type": "v1_past_meeting_transcript",
       "human_label": "past meeting transcripts"
     }
   ]
@@ -187,7 +189,7 @@ a query-service entry for read will receive JTBDs from both sources.
 Issue **all** live-endpoint fetches as a single parallel batch — do not fetch
 them one at a time. For each entry in `/tmp/openapi_paths.json`:
 
-```
+```text
 GET https://lfx-api.dev.v2.cluster.linuxfound.info<openapi3.json path>
 ```
 
@@ -196,7 +198,7 @@ GET https://lfx-api.dev.v2.cluster.linuxfound.info<openapi3.json path>
 Search the `linuxfoundation` GitHub organization for `openapi3.json` using the
 RuleSet `metadata.name` as the repo name hint:
 
-```
+```text
 filename:openapi3.json repo:linuxfoundation/<ruleset-metadata-name>
 ```
 
@@ -225,7 +227,7 @@ descriptions as before.
 entry, scoped to viewing that child resource. For example, an entry with
 `human_label: "past meeting recordings"` on `v1_past_meeting#viewer` produces:
 
-```
+```text
 View past meeting recordings
 ```
 

--- a/.agents/skills/populate-jtbds/SKILL.md
+++ b/.agents/skills/populate-jtbds/SKILL.md
@@ -25,12 +25,16 @@ the JTBD annotations need to be refreshed from real API usage.
 - `@fgadoc:hide` objects and relations are **not** excluded from JTBD
   processing. If a hidden type or relation has matching RuleSet routes,
   synthesize and write JTBDs for it exactly as you would for a visible one.
-- Some object types are served exclusively by the **Query Service**, which
-  uses relation annotations on indexed items rather than Heimdall RuleSets.
-  These types will have zero RuleSet entries and cannot be populated by this
-  skill — that is expected, not a bug. Known Query Service-only types:
-  `v1_past_meeting_recording`, `v1_past_meeting_transcript`. Do not flag
-  them as needing manual review.
+- Some object types have relations that are enforced by the **Query Service**
+  rather than Heimdall RuleSets. The Query Service reads `access_check_object`
+  and `access_check_relation` fields embedded in indexed documents to determine
+  which OpenFGA object and relation to check — typically delegating to a parent
+  object type (e.g., a recording delegates its `viewer` check to the parent
+  `v1_past_meeting`). These relations will have zero RuleSet entries; their
+  JTBDs are synthesized from indexer contracts in Step 2b.
+- An indexed object type may not appear in `model.yaml` at all (e.g.,
+  `v1_meeting_registrant`). Step 2b writes JTBDs onto the `access_check_object`
+  type's relation in `model.yaml`, **not** onto the indexed type itself.
 
 ## Discipline rules — read before synthesizing any JTBD
 
@@ -48,12 +52,12 @@ does. The `summary` is often a terse label and the path pattern can be
 misleading. If a route has no `description`, fall back to `summary`, and flag
 it for manual review.
 
-**3. No RuleSet checks → no JTBD.** If a relation has no routes in the
-extracted groups (i.e. it is not present in `/tmp/openfga_groups.json`), leave
-it with zero `@fgadoc:jtbd` lines. Do not invent plausible-sounding statements.
+**3. No coverage from either source → no JTBD.** If a relation has no routes
+in `/tmp/openfga_groups.json` (RuleSets) **and** no entry in
+`/tmp/query_service_groups.json` (indexer contracts), leave it with zero
+`@fgadoc:jtbd` lines. Do not invent plausible-sounding statements.
 A `@fgadoc:hide` annotation does **not** exempt an object or relation from this
-rule — hidden objects with RuleSet routes still get JTBDs; hidden objects
-without routes still get none.
+rule.
 
 **4. Do not generalize write verbs.** Only use `Create & manage` or
 `Update & delete` if *both* a creation route (POST) **and** an
@@ -121,6 +125,63 @@ Note: the `object` value may be a Heimdall template like
 `{{- .Request.Body.committee_uid -}}` — strip everything after the `:` to get
 the object type.
 
+## Step 2b — Discover Query Service authorization from indexer contracts
+
+In parallel with or immediately after Step 2, fetch all indexer contract
+documents from GitHub to discover which `object#relation` pairs are enforced
+by the Query Service rather than Heimdall.
+
+**Search for all contracts:**
+
+```
+filename:indexer-contract.md org:linuxfoundation
+```
+
+Fetch every result's file contents via the GitHub API in a single parallel
+batch (use the `repo` and `path` from each search result).
+
+**Parse each contract** to extract, for every resource type section:
+
+- `object_type` — from the `**Object type:** \`...\`` line
+- `access_check_object` — from the `Access Control (IndexingConfig)` table row
+- `access_check_relation` — from the same table
+
+Strip the `:{...}` suffix from `access_check_object` to get the **delegate
+type** (e.g., `v1_past_meeting:{meeting_and_occurrence_id}` →
+`v1_past_meeting`).
+
+A resource type contributes a Query Service entry when its `access_check_object`
+delegate type **differs** from its own `object_type` (meaning the Query Service
+delegates authorization upward to a parent object).
+
+Write `/tmp/query_service_groups.json` in this shape:
+
+```json
+{
+  "v1_past_meeting#viewer": [
+    {
+      "indexed_type": "v1_past_meeting_recording",
+      "human_label": "past meeting recordings"
+    },
+    {
+      "indexed_type": "v1_past_meeting_transcript",
+      "human_label": "past meeting transcripts"
+    }
+  ]
+}
+```
+
+The key is `<delegate_type>#<access_check_relation>` — the OpenFGA
+`object#relation` that the Query Service actually checks. The `human_label` is
+a short plural noun derived from the `object_type` by stripping the leading
+`v1_` prefix and replacing underscores with spaces (e.g.,
+`v1_past_meeting_recording` → `past meeting recordings`).
+
+**Union with RuleSet groups:** When generating JTBDs in Step 4, treat entries
+in `/tmp/query_service_groups.json` as additional coverage for the delegate
+`object#relation`. A relation that has RuleSet entries for write operations but
+a query-service entry for read will receive JTBDs from both sources.
+
 ## Step 3 — Fetch ALL OpenAPI specs in parallel
 
 Issue **all** live-endpoint fetches as a single parallel batch — do not fetch
@@ -152,9 +213,24 @@ Fall back to `summary` only if no `description` is present.
 ## Step 4 — Synthesize JTBD statements
 
 For each `<object>#<relation>` group you now have a set of API operation
-descriptions. The existing `@fgadoc:jtbd` lines already in `model.yaml` are
-the canonical style reference — match their grammar, verb choices, and
-phrasing when writing new statements.
+descriptions (from RuleSets) and/or a list of indexed child types (from indexer
+contracts). The existing `@fgadoc:jtbd` lines already in `model.yaml` are the
+canonical style reference — match their grammar, verb choices, and phrasing
+when writing new statements.
+
+**For RuleSet-sourced groups:** synthesize from the OpenAPI operation
+descriptions as before.
+
+**For Query Service-sourced groups:** synthesize one JTBD per `human_label`
+entry, scoped to viewing that child resource. For example, an entry with
+`human_label: "past meeting recordings"` on `v1_past_meeting#viewer` produces:
+
+```
+View past meeting recordings
+```
+
+If a relation has entries from **both** sources, include all JTBDs — RuleSet
+statements first, then Query Service statements.
 
 **JTBD style rules:**
 - Start with an imperative verb: *View*, *Create*, *Manage*, *Update*,
@@ -190,6 +266,10 @@ automatically but include the summary in the final report.
 For each confirmed `<object>#<relation>` group:
 
 1. Find the `define <relation>:` line within the correct `type` block.
+   - For RuleSet-sourced groups, `<object>` is the type block to target.
+   - For Query Service-sourced groups, `<object>` is the **delegate type**
+     (e.g., `v1_past_meeting`), not the indexed type. Write onto the delegate
+     type's relation block even if the indexed type also exists in `model.yaml`.
 2. **Replace** only the `# @fgadoc:jtbd` lines in the comment block
    immediately above that `define`. Leave all other lines untouched.
 3. The comment format must be:
@@ -200,7 +280,7 @@ For each confirmed `<object>#<relation>` group:
             define <relation>: ...
 ```
 
-Leave unchanged any `define` lines not covered by a RuleSet rule.
+Leave unchanged any `define` lines not covered by either source.
 
 ## Step 7 — Fix indentation
 
@@ -233,6 +313,7 @@ If any of these checks fail, revert and report the issue.
 ## Output
 
 Report:
-- How many `<object>#<relation>` groups were processed.
+- How many `<object>#<relation>` groups were processed (broken down by source:
+  RuleSets vs. indexer contracts vs. both).
 - How many JTBD statements were written.
 - Any relations flagged for manual review (no OpenAPI description found).

--- a/.agents/skills/populate-jtbds/SKILL.md
+++ b/.agents/skills/populate-jtbds/SKILL.md
@@ -82,17 +82,17 @@ Parse `/tmp/rulesets.json` **once** with a single Python script that produces
 two output files:
 
 - `/tmp/openfga_groups.json` — routes grouped by `<object>#<relation>`
-- `/tmp/openapi_paths.json` — `{ "<ruleset-name>": "<openapi3.yaml path>" }`
+- `/tmp/openapi_paths.json` — `{ "<ruleset-name>": "<openapi3.json path>" }`
 
 For each rule, collect:
 
 - `ruleset` — `metadata.name` of the RuleSet
 - `method` — HTTP method (GET, POST, PATCH, DELETE, …)
-- `route` — URL path pattern (excluding openapi3.yaml routes)
+- `route` — URL path pattern (excluding openapi3.json routes)
 - `object` — OpenFGA object type (strip `:...` variable suffix)
 - `relation` — OpenFGA relation required
 
-Also record any route whose path ends in `openapi3.yaml` into the openapi
+Also record any route whose path ends in `openapi3.json` into the openapi
 paths map at the same time.
 
 Typical RuleSet shape (abbreviated):
@@ -188,16 +188,16 @@ Issue **all** live-endpoint fetches as a single parallel batch — do not fetch
 them one at a time. For each entry in `/tmp/openapi_paths.json`:
 
 ```
-GET https://lfx-api.dev.v2.cluster.linuxfound.info<openapi3.yaml path>
+GET https://lfx-api.dev.v2.cluster.linuxfound.info<openapi3.json path>
 ```
 
 **GitHub fallback (for any that return non-200):**
 
-Search the `linuxfoundation` GitHub organization for `openapi3.yaml` using the
+Search the `linuxfoundation` GitHub organization for `openapi3.json` using the
 RuleSet `metadata.name` as the repo name hint:
 
 ```
-filename:openapi3.yaml repo:linuxfoundation/<ruleset-metadata-name>
+filename:openapi3.json repo:linuxfoundation/<ruleset-metadata-name>
 ```
 
 Use GitHub code search to locate and read the file. If multiple services fail,

--- a/.agents/skills/populate-jtbds/SKILL.md
+++ b/.agents/skills/populate-jtbds/SKILL.md
@@ -34,9 +34,9 @@ the JTBD annotations need to be refreshed from real API usage.
   JTBDs are synthesized from indexer contracts in Step 2b.
 - An indexed object type may not appear in `model.yaml` at all (e.g.,
   `v1_meeting_registrant`). Step 2b writes JTBDs onto the **delegate type**'s
-  relation in `model.yaml` — that is, the `access_check_object` value with any
-  `:<id>` suffix stripped (e.g. `v1_past_meeting:{meeting_and_occurrence_id}` →
-  `v1_past_meeting`) — **not** onto the indexed type itself.
+  relation in `model.yaml` — that is, `access_check_object` with everything
+  after the first `:` stripped (e.g. `v1_past_meeting:{meeting_and_occurrence_id}`
+  → `v1_past_meeting`) — **not** onto the source `object_type` itself.
 
 ## Discipline rules — read before synthesizing any JTBD
 
@@ -270,8 +270,9 @@ For each confirmed `<object>#<relation>` group:
 1. Find the `define <relation>:` line within the correct `type` block.
    - For RuleSet-sourced groups, `<object>` is the type block to target.
    - For Query Service-sourced groups, `<object>` is the **delegate type**
-     (e.g., `v1_past_meeting`), not the indexed type. Write onto the delegate
-     type's relation block even if the indexed type also exists in `model.yaml`.
+     (e.g., `v1_past_meeting`), not the source `object_type`. Write onto the
+     delegate type's relation block even if the `object_type` also exists in
+     `model.yaml`.
 2. **Replace** only the `# @fgadoc:jtbd` lines in the comment block
    immediately above that `define`. Leave all other lines untouched.
 3. The comment format must be:

--- a/PERMISSIONS.md
+++ b/PERMISSIONS.md
@@ -32,12 +32,15 @@ role assignment.
 | View project membership tiers | ✅ | ✅ | | |
 | View project memberships & member companies | ✅ | ✅ | | |
 | View project membership key contacts | ✅ | ✅ | | |
+| Search B2B organizations | ✅ | ✅ | | |
+| View B2B organization memberships | ✅ | ✅ | | |
 | Manage project membership key contacts | ✅ | | | |
 | Update project settings | ✅ | | | |
 | Create & update a project | ✅ | | | |
 | Create a vote | ✅ | | | |
 | Create project committees & mailing lists | ✅ | | | |
 | Create project meetings | ✅ | | ✅ | |
+| Create past meetings | ✅ | | ✅ | |
 
 #### Permission Inheritance
 
@@ -50,11 +53,17 @@ role assignment.
 
 | | Writer | Auditor | Member | *Everyone* |
 |---|---|---|---|---|
-| View committee details, members, invites & resources | ✅ | ✅ | ✅ | 🟡 |
+| View committee details | ✅ | ✅ | ✅ | 🟡 |
+| View committee members | ✅ | ✅ | ✅ | 🟡 |
+| View committee invites | ✅ | ✅ | ✅ | 🟡 |
+| View committee applications | ✅ | ✅ | ✅ | 🟡 |
+| View committee links | ✅ | ✅ | ✅ | 🟡 |
+| View committee link folders | ✅ | ✅ | ✅ | 🟡 |
+| Download committee documents | ✅ | ✅ | ✅ | 🟡 |
 | View committee settings | ✅ | ✅ | | |
-| Update committee settings | ✅ | | | |
 | Manage committee members, invites & applications | ✅ | | | |
-| Manage committee links & folders | ✅ | | | |
+| Manage committee links, folders & documents | ✅ | | | |
+| Update committee settings | ✅ | | | |
 | Update & delete a committee | ✅ | | | |
 | Schedule a survey for a committee | ✅ | | | |
 
@@ -84,8 +93,9 @@ role assignment.
 
 | | Writer | Auditor | Subscriber | *Everyone* |
 |---|---|---|---|---|
-| View a mailing list & its members | ✅ | ✅ | ✅ | 🟡 |
+| View a mailing list | ✅ | ✅ | ✅ | 🟡 |
 | View & download mailing list artifacts | ✅ | ✅ | ✅ | 🟡 |
+| View mailing list members | ✅ | ✅ | ✅ | 🟡 |
 | Add & remove mailing list members | ✅ | | | |
 | Update & delete a mailing list | ✅ | | | |
 
@@ -100,9 +110,12 @@ role assignment.
 
 | | *Organizer* | *Auditor* | Host | Participant | *Everyone* |
 |---|---|---|---|---|---|
-| View a meeting & its attachments | ✅ | ✅ | ✅ | ✅ | 🟡 |
+| View a meeting | ✅ | ✅ | ✅ | ✅ | 🟡 |
 | Submit a meeting response | ✅ | ✅ | ✅ | ✅ | 🟡 |
 | Get meeting join link & ICS file | ✅ | ✅ | ✅ | ✅ | 🟡 |
+| View meeting registrants | ✅ | ✅ | ✅ | ✅ | 🟡 |
+| View meeting RSVPs | ✅ | ✅ | ✅ | ✅ | 🟡 |
+| View meeting attachments | ✅ | ✅ | ✅ | ✅ | 🟡 |
 | View a meeting registrant | ✅ | ✅ | | | |
 | Manage meeting attachments | ✅ | | | | |
 | Manage meeting registrants & occurrences | ✅ | | | | |
@@ -119,9 +132,14 @@ role assignment.
 
 | | *Organizer* | *Auditor* | Host | Invitee | Attendee | *Everyone* |
 |---|---|---|---|---|---|---|
-| View a past meeting & its attachments | ✅ | ✅ | ✅ | ✅ | ✅ | 🟡 |
-| View a past meeting summary | ✅ | ✅ | 🟡 | 🟡 | 🟡 | 🟡 |
-| Update a past meeting summary | ✅ | ✅ | | | | |
+| View a past meeting | ✅ | ✅ | ✅ | ✅ | ✅ | 🟡 |
+| View past meeting participants | ✅ | ✅ | ✅ | ✅ | ✅ | 🟡 |
+| View past meeting recordings | ✅ | ✅ | ✅ | ✅ | ✅ | 🟡 |
+| View past meeting transcripts | ✅ | ✅ | ✅ | ✅ | ✅ | 🟡 |
+| View past meeting summaries | ✅ | ✅ | ✅ | ✅ | ✅ | 🟡 |
+| View past meeting attachments | ✅ | ✅ | ✅ | ✅ | ✅ | 🟡 |
+| View a past meeting summary | ✅ | ✅ | ✅ | 🟡 | 🟡 | 🟡 |
+| Update a past meeting summary | ✅ | ✅ | ✅ | | | |
 | Manage past meeting participants & attachments | ✅ | | | | | |
 | Update & delete a past meeting | ✅ | | | | | |
 
@@ -137,6 +155,7 @@ role assignment.
 | | *Writer* | *Auditor* | Participant | *Everyone* |
 |---|---|---|---|---|
 | View a vote & its status | ✅ | ✅ | ✅ | 🟡 |
+| View vote responses | ✅ | ✅ | ✅ | 🟡 |
 | View aggregated voting results | ✅ | ✅ | | 🟡 |
 | Cast a vote response | | | ✅ | |
 | Extend, enable & resend a vote | ✅ | | | |
@@ -167,6 +186,7 @@ role assignment.
 | | *Writer* | *Auditor* | Participant | *Everyone* |
 |---|---|---|---|---|
 | View a survey | ✅ | ✅ | ✅ | 🟡 |
+| View survey responses | ✅ | ✅ | ✅ | 🟡 |
 | Preview survey send recipients | ✅ | ✅ | | |
 | Manage survey recipients & responses | ✅ | | | |
 | Update & delete a survey | ✅ | | | |

--- a/PERMISSIONS.md
+++ b/PERMISSIONS.md
@@ -24,23 +24,23 @@ role assignment.
 
 ### Project
 
-| | Writer | Auditor | Meeting Coordinator | *Everyone* |
-|---|---|---|---|---|
-| View a project | ✅ | ✅ | ✅ | 🟡 |
-| View project meeting count | ✅ | ✅ | ✅ | 🟡 |
-| View project settings | ✅ | ✅ | | |
-| View project membership tiers | ✅ | ✅ | | |
-| View project memberships & member companies | ✅ | ✅ | | |
-| View project membership key contacts | ✅ | ✅ | | |
-| Search B2B organizations | ✅ | ✅ | | |
-| View B2B organization memberships | ✅ | ✅ | | |
-| Manage project membership key contacts | ✅ | | | |
-| Update project settings | ✅ | | | |
-| Create & update a project | ✅ | | | |
-| Create a vote | ✅ | | | |
-| Create project committees & mailing lists | ✅ | | | |
-| Create project meetings | ✅ | | ✅ | |
-| Create past meetings | ✅ | | ✅ | |
+| | Writer | Auditor | Meeting Coordinator | Executive Director | *Everyone* |
+|---|---|---|---|---|---|
+| View a project | ✅ | ✅ | ✅ | ✅ | 🟡 |
+| View project meeting count | ✅ | ✅ | ✅ | ✅ | 🟡 |
+| View project settings | ✅ | ✅ | | ✅ | |
+| View project membership tiers | ✅ | ✅ | | ✅ | |
+| View project memberships & member companies | ✅ | ✅ | | ✅ | |
+| View project membership key contacts | ✅ | ✅ | | ✅ | |
+| Search B2B organizations | ✅ | ✅ | | ✅ | |
+| View B2B organization memberships | ✅ | ✅ | | ✅ | |
+| Manage project membership key contacts | ✅ | | | | |
+| Update project settings | ✅ | | | | |
+| Create & update a project | ✅ | | | | |
+| Create a vote | ✅ | | | | |
+| Create project committees & mailing lists | ✅ | | | | |
+| Create project meetings | ✅ | | ✅ | | |
+| Create past meetings | ✅ | | ✅ | | |
 
 #### Permission Inheritance
 
@@ -54,13 +54,13 @@ role assignment.
 | | Writer | Auditor | Member | *Everyone* |
 |---|---|---|---|---|
 | View committee details | ✅ | ✅ | ✅ | 🟡 |
+| View committee settings | ✅ | ✅ | | |
 | View committee members | ✅ | ✅ | ✅ | 🟡 |
 | View committee invites | ✅ | ✅ | ✅ | 🟡 |
 | View committee applications | ✅ | ✅ | ✅ | 🟡 |
 | View committee links | ✅ | ✅ | ✅ | 🟡 |
 | View committee link folders | ✅ | ✅ | ✅ | 🟡 |
 | Download committee documents | ✅ | ✅ | ✅ | 🟡 |
-| View committee settings | ✅ | ✅ | | |
 | Manage committee members, invites & applications | ✅ | | | |
 | Manage committee links, folders & documents | ✅ | | | |
 | Update committee settings | ✅ | | | |
@@ -79,6 +79,7 @@ role assignment.
 | | Writer | Auditor | *Everyone* |
 |---|---|---|---|
 | View a Groups.io service | ✅ | ✅ | 🟡 |
+| View Groups.io service settings | ✅ | ✅ | |
 | Update & delete a Groups.io service | ✅ | | |
 | Create project mailing lists | ✅ | | |
 
@@ -94,6 +95,7 @@ role assignment.
 | | Writer | Auditor | Subscriber | *Everyone* |
 |---|---|---|---|---|
 | View a mailing list | ✅ | ✅ | ✅ | 🟡 |
+| View mailing list settings | ✅ | ✅ | | |
 | View & download mailing list artifacts | ✅ | ✅ | ✅ | 🟡 |
 | View mailing list members | ✅ | ✅ | ✅ | 🟡 |
 | Add & remove mailing list members | ✅ | | | |
@@ -111,12 +113,12 @@ role assignment.
 | | *Organizer* | *Auditor* | Host | Participant | *Everyone* |
 |---|---|---|---|---|---|
 | View a meeting | ✅ | ✅ | ✅ | ✅ | 🟡 |
+| View meeting registrants | ✅ | ✅ | ✅ | ✅ | 🟡 |
+| View a meeting registrant | ✅ | ✅ | | | |
+| View meeting RSVPs | ✅ | ✅ | ✅ | ✅ | 🟡 |
 | Submit a meeting response | ✅ | ✅ | ✅ | ✅ | 🟡 |
 | Get meeting join link & ICS file | ✅ | ✅ | ✅ | ✅ | 🟡 |
-| View meeting registrants | ✅ | ✅ | ✅ | ✅ | 🟡 |
-| View meeting RSVPs | ✅ | ✅ | ✅ | ✅ | 🟡 |
 | View meeting attachments | ✅ | ✅ | ✅ | ✅ | 🟡 |
-| View a meeting registrant | ✅ | ✅ | | | |
 | Manage meeting attachments | ✅ | | | | |
 | Manage meeting registrants & occurrences | ✅ | | | | |
 | Update & delete a meeting | ✅ | | | | |
@@ -137,8 +139,8 @@ role assignment.
 | View past meeting recordings | ✅ | ✅ | ✅ | ✅ | ✅ | 🟡 |
 | View past meeting transcripts | ✅ | ✅ | ✅ | ✅ | ✅ | 🟡 |
 | View past meeting summaries | ✅ | ✅ | ✅ | ✅ | ✅ | 🟡 |
+| View a past meeting summary | ✅ | ✅ | 🟡 | 🟡 | 🟡 | 🟡 |
 | View past meeting attachments | ✅ | ✅ | ✅ | ✅ | ✅ | 🟡 |
-| View a past meeting summary | ✅ | ✅ | ✅ | 🟡 | 🟡 | 🟡 |
 | Update a past meeting summary | ✅ | ✅ | ✅ | | | |
 | Manage past meeting participants & attachments | ✅ | | | | | |
 | Update & delete a past meeting | ✅ | | | | | |

--- a/charts/lfx-platform/templates/openfga/model.yaml
+++ b/charts/lfx-platform/templates/openfga/model.yaml
@@ -59,9 +59,12 @@ spec:
             # @fgadoc:jtbd View project membership tiers
             # @fgadoc:jtbd View project memberships & member companies
             # @fgadoc:jtbd View project membership key contacts
+            # @fgadoc:jtbd Search B2B organizations
+            # @fgadoc:jtbd View B2B organization memberships
             define auditor: [user, team#member] or writer or auditor from parent
             define meeting_coordinator: [user]
             # @fgadoc:jtbd Create project meetings
+            # @fgadoc:jtbd Create past meetings
             define meetings_creator: writer or meeting_coordinator
             # @fgadoc:jtbd View a project
             # @fgadoc:jtbd View project meeting count
@@ -74,12 +77,18 @@ spec:
             # @fgadoc:jtbd Update & delete a committee
             # @fgadoc:jtbd Update committee settings
             # @fgadoc:jtbd Manage committee members, invites & applications
-            # @fgadoc:jtbd Manage committee links & folders
+            # @fgadoc:jtbd Manage committee links, folders & documents
             # @fgadoc:jtbd Schedule a survey for a committee
             define writer: [user] or writer from project
             # @fgadoc:jtbd View committee settings
             define auditor: [user, team#member] or writer or auditor from project or meeting_coordinator from project
-            # @fgadoc:jtbd View committee details, members, invites & resources
+            # @fgadoc:jtbd View committee details
+            # @fgadoc:jtbd Download committee documents
+            # @fgadoc:jtbd View committee members
+            # @fgadoc:jtbd View committee invites
+            # @fgadoc:jtbd View committee applications
+            # @fgadoc:jtbd View committee links
+            # @fgadoc:jtbd View committee link folders
             define viewer: [user:*] or member or auditor
 
         # @fgadoc:alias Groups.io Service
@@ -103,8 +112,9 @@ spec:
             # @fgadoc:jtbd Add & remove mailing list members
             define writer: [user] or writer from groupsio_service or writer from committee
             define auditor: [user] or auditor from groupsio_service or auditor from committee
-            # @fgadoc:jtbd View a mailing list & its members
+            # @fgadoc:jtbd View a mailing list
             # @fgadoc:jtbd View & download mailing list artifacts
+            # @fgadoc:jtbd View mailing list members
             define viewer: [user:*] or writer or auditor or member
             # @fgadoc:alias Subscriber
             define member: [user]
@@ -279,9 +289,12 @@ spec:
             define organizer: meeting_coordinator from project or writer from committee or writer from project
             define host: [user] or organizer
             define participant: [user] or host
-            # @fgadoc:jtbd View a meeting & its attachments
+            # @fgadoc:jtbd View a meeting
             # @fgadoc:jtbd Submit a meeting response
             # @fgadoc:jtbd Get meeting join link & ICS file
+            # @fgadoc:jtbd View meeting registrants
+            # @fgadoc:jtbd View meeting RSVPs
+            # @fgadoc:jtbd View meeting attachments
             define viewer: [user:*] or participant or organizer or auditor
 
         # *All relations are as described in `past_meeting`, unless otherwise noted.*
@@ -299,7 +312,12 @@ spec:
             define host: [user] or organizer
             define invitee: [user]
             define attendee: [user]
-            # @fgadoc:jtbd View a past meeting & its attachments
+            # @fgadoc:jtbd View a past meeting
+            # @fgadoc:jtbd View past meeting participants
+            # @fgadoc:jtbd View past meeting recordings
+            # @fgadoc:jtbd View past meeting transcripts
+            # @fgadoc:jtbd View past meeting summaries
+            # @fgadoc:jtbd View past meeting attachments
             define viewer: [user:*] or attendee or invitee or host or organizer or auditor
 
         # *All relations are as described in `past_meeting_recording`, unless
@@ -371,6 +389,7 @@ spec:
             # @fgadoc:jtbd Cast a vote response
             define participant: [user]
             # @fgadoc:jtbd View a vote & its status
+            # @fgadoc:jtbd View vote responses
             define viewer: [user:*] or auditor or participant
             define vote_for_participant_result_access: [vote] # set this relation to "self" to enable access
             # results_viewer is not for viewing the actual related vote_response objects,
@@ -402,6 +421,7 @@ spec:
             define auditor: writer or auditor from project or auditor from committee
             define participant: [user]
             # @fgadoc:jtbd View a survey
+            # @fgadoc:jtbd View survey responses
             define viewer: [user:*] or auditor or participant
             define survey_for_participant_result_access: [survey] # set this relation to "self" to enable access
             # results_viewer is not for viewing the actual related survey_response objects,

--- a/charts/lfx-platform/templates/openfga/model.yaml
+++ b/charts/lfx-platform/templates/openfga/model.yaml
@@ -18,6 +18,9 @@ spec:
     - minor: Additions or deletions of relations
     - patch: Modifications of define
 
+  Changes to @fgadoc:jtbd, @fgadoc:alias, @fgadoc:hide, or @fgadoc:collapse
+  annotations are documentation only and do NOT require a version bump.
+
   Do NOT add @fgadoc:jtbd lines manually. These are updated by the
   `populate-jtbds` skill by analyzing live RuleSets and API docs.
   @fgadoc:hide, @fgadoc:alias, @fgadoc:collapse tags are managed manually.

--- a/charts/lfx-platform/templates/openfga/model.yaml
+++ b/charts/lfx-platform/templates/openfga/model.yaml
@@ -38,6 +38,7 @@ spec:
           relations
             # @fgadoc:jtbd Manage survey email exclusions
             # @fgadoc:jtbd Validate survey email templates
+            # @fgadoc:jtbd View survey email templates
             define member: [user]
 
         type project
@@ -103,6 +104,7 @@ spec:
             # @fgadoc:jtbd Update & delete a Groups.io service
             # @fgadoc:jtbd Create project mailing lists
             define writer: [user] or writer from project
+            # @fgadoc:jtbd View Groups.io service settings
             define auditor: [user] or auditor from project or writer
             # @fgadoc:jtbd View a Groups.io service
             define viewer: [user:*] or auditor
@@ -116,6 +118,7 @@ spec:
             # @fgadoc:jtbd Update & delete a mailing list
             # @fgadoc:jtbd Add & remove mailing list members
             define writer: [user] or writer from groupsio_service or writer from committee
+            # @fgadoc:jtbd View mailing list settings
             define auditor: [user] or auditor from groupsio_service or auditor from committee
             # @fgadoc:jtbd View a mailing list
             # @fgadoc:jtbd View & download mailing list artifacts
@@ -331,6 +334,7 @@ spec:
             define past_meeting_for_participant_recording_view: [v1_past_meeting]
             define past_meeting_for_attendee_recording_view: [v1_past_meeting]
             define past_meeting_for_host_recording_view: [v1_past_meeting]
+            # @fgadoc:jtbd View past meeting recordings
             define recording_viewer: [user:*] or organizer or auditor or invitee from past_meeting_for_participant_recording_view or attendee from past_meeting_for_attendee_recording_view or host from past_meeting_for_host_recording_view
             # Per-artifact conditional access — transcript
             # Self-referential flag tuple: write relation(object=v1_past_meeting:<id>, user=v1_past_meeting:<id>)
@@ -338,6 +342,7 @@ spec:
             define past_meeting_for_participant_transcript_view: [v1_past_meeting]
             define past_meeting_for_attendee_transcript_view: [v1_past_meeting]
             define past_meeting_for_host_transcript_view: [v1_past_meeting]
+            # @fgadoc:jtbd View past meeting transcripts
             define transcript_viewer: [user:*] or organizer or auditor or invitee from past_meeting_for_participant_transcript_view or attendee from past_meeting_for_attendee_transcript_view or host from past_meeting_for_host_transcript_view
             # Per-artifact conditional access — AI summary
             # Self-referential flag tuple: write relation(object=v1_past_meeting:<id>, user=v1_past_meeting:<id>)
@@ -345,6 +350,7 @@ spec:
             define past_meeting_for_participant_summary_view: [v1_past_meeting]
             define past_meeting_for_attendee_summary_view: [v1_past_meeting]
             define past_meeting_for_host_summary_view: [v1_past_meeting]
+            # @fgadoc:jtbd View a past meeting summary
             define ai_summary_viewer: [user:*] or organizer or auditor or invitee from past_meeting_for_participant_summary_view or attendee from past_meeting_for_attendee_summary_view or host from past_meeting_for_host_summary_view
 
         # *All relations are as described in `past_meeting_recording`, unless


### PR DESCRIPTION
## Summary

- Adds **Step 2b** to the `populate-jtbds` skill: fetches all `indexer-contract.md` files across `linuxfoundation` repos via GitHub code search, parses their Access Control tables, and builds `/tmp/query_service_groups.json` mapping each `<delegate_type>#<relation>` to the indexed child resource types it covers.
- Steps 4 and 6 are updated to **union** RuleSet groups and indexer contract groups — a relation covered by either or both sources receives JTBDs. Query Service JTBDs are written onto the delegate type's relation block in `model.yaml` (not the indexed type itself, which may not even exist in the model).
- Updates the Gotchas section with an accurate description of how Query Service authorization actually works, and removes the hardcoded list of known Query Service-only types.
- Tightens discipline rule 3 to reference both sources.

## Jira

LFXV2-1430 — Extend populate-jtbds skill to cover Query Service authorization (relation annotations on indexed items)

🤖 Generated with [GitHub Copilot](https://github.com/features/copilot) (via OpenCode)