### PR TITLE
[LFXV2-1505] Add per-artifact viewer relations to v1_past_meeting FGA type

### DIFF
--- a/charts/lfx-platform/templates/openfga/model.yaml
+++ b/charts/lfx-platform/templates/openfga/model.yaml
@@ -302,16 +302,23 @@ spec:
             # @fgadoc:jtbd View a past meeting & its attachments
             define viewer: [user:*] or attendee or invitee or host or organizer or auditor
             # Per-artifact conditional access — recording
+            # "participant" access level means invitee+attendee (both can view).
+            # Self-referential flag tuple: write relation(object=v1_past_meeting:<id>, user=v1_past_meeting:<id>)
+            # on the appropriate relation(s) to grant that role access to the recording.
             define past_meeting_for_participant_recording_view: [v1_past_meeting]
             define past_meeting_for_attendee_recording_view: [v1_past_meeting]
             define past_meeting_for_host_recording_view: [v1_past_meeting]
             define recording_viewer: [user:*] or organizer or auditor or invitee from past_meeting_for_participant_recording_view or attendee from past_meeting_for_attendee_recording_view or host from past_meeting_for_host_recording_view
             # Per-artifact conditional access — transcript
+            # Self-referential flag tuple: write relation(object=v1_past_meeting:<id>, user=v1_past_meeting:<id>)
+            # on the appropriate relation(s) to grant that role access to the transcript.
             define past_meeting_for_participant_transcript_view: [v1_past_meeting]
             define past_meeting_for_attendee_transcript_view: [v1_past_meeting]
             define past_meeting_for_host_transcript_view: [v1_past_meeting]
             define transcript_viewer: [user:*] or organizer or auditor or invitee from past_meeting_for_participant_transcript_view or attendee from past_meeting_for_attendee_transcript_view or host from past_meeting_for_host_transcript_view
             # Per-artifact conditional access — AI summary
+            # Self-referential flag tuple: write relation(object=v1_past_meeting:<id>, user=v1_past_meeting:<id>)
+            # on the appropriate relation(s) to grant that role access to the AI summary.
             define past_meeting_for_participant_summary_view: [v1_past_meeting]
             define past_meeting_for_attendee_summary_view: [v1_past_meeting]
             define past_meeting_for_host_summary_view: [v1_past_meeting]

--- a/charts/lfx-platform/templates/openfga/model.yaml
+++ b/charts/lfx-platform/templates/openfga/model.yaml
@@ -23,8 +23,8 @@ spec:
   @fgadoc:hide, @fgadoc:alias, @fgadoc:collapse tags are managed manually.
 */}}
     - version:
-        major: 10
-        minor: 1
+        major: 11
+        minor: 0
         patch: 0
       authorizationModel: |
         model

--- a/charts/lfx-platform/templates/openfga/model.yaml
+++ b/charts/lfx-platform/templates/openfga/model.yaml
@@ -329,6 +329,63 @@ spec:
             define past_meeting_for_host_summary_view: [v1_past_meeting]
             define ai_summary_viewer: [user:*] or organizer or auditor or invitee from past_meeting_for_participant_summary_view or attendee from past_meeting_for_attendee_summary_view or host from past_meeting_for_host_summary_view
 
+        # *All relations are as described in `past_meeting_recording`, unless
+        # otherwise noted.*
+        # @fgadoc:collapse v1_past_meeting
+        type v1_past_meeting_recording
+          relations
+            define past_meeting: [v1_past_meeting]
+            define writer: organizer from past_meeting
+            define auditor: auditor from past_meeting
+            define host: host from past_meeting
+            define participant: invitee from past_meeting or attendee from past_meeting
+            # The following "participant access by related meeting" relations are conditional
+            # because they depend on the past meeting artifact_visibility setting. Auditors
+            # and writers do however by default have access to view the recording.
+            define past_meeting_for_participant_view: [v1_past_meeting]
+            define past_meeting_for_attendee_view: [v1_past_meeting]
+            define past_meeting_for_host_view: [v1_past_meeting]
+            # If the artifact_visibility is public, then every user should be a viewer
+            define viewer: [user:*] or writer or auditor or invitee from past_meeting_for_participant_view or attendee from past_meeting_for_attendee_view or host from past_meeting_for_host_view
+
+        # *All relations are as described in `past_meeting_transcript`, unless
+        # otherwise noted.*
+        # @fgadoc:collapse v1_past_meeting
+        type v1_past_meeting_transcript
+          relations
+            define past_meeting: [v1_past_meeting]
+            define writer: organizer from past_meeting
+            define auditor: auditor from past_meeting
+            define host: host from past_meeting
+            define participant: invitee from past_meeting or attendee from past_meeting
+            # The following "participant access by related meeting" relations are conditional
+            # because they depend on the past meeting artifact_visibility setting. Auditors
+            # and writers do however by default have access to view the transcript.
+            define past_meeting_for_participant_view: [v1_past_meeting]
+            define past_meeting_for_attendee_view: [v1_past_meeting]
+            define past_meeting_for_host_view: [v1_past_meeting]
+            # If the artifact_visibility is public, then every user should be a viewer
+            define viewer: [user:*] or writer or auditor or invitee from past_meeting_for_participant_view or attendee from past_meeting_for_attendee_view or host from past_meeting_for_host_view
+
+        # @fgadoc:collapse v1_past_meeting
+        type v1_past_meeting_summary
+          relations
+            define past_meeting: [v1_past_meeting]
+            # @fgadoc:jtbd Update a past meeting summary
+            define writer: organizer from past_meeting
+            define auditor: auditor from past_meeting
+            define host: host from past_meeting
+            define participant: invitee from past_meeting or attendee from past_meeting
+            # The following "participant access by related meeting" relations are conditional
+            # because they depend on the past meeting artifact_visibility setting. Auditors
+            # and writers do however by default have access to view the summary.
+            define past_meeting_for_participant_view: [v1_past_meeting]
+            define past_meeting_for_attendee_view: [v1_past_meeting]
+            define past_meeting_for_host_view: [v1_past_meeting]
+            # If the artifact_visibility is public, then every user should be a viewer
+            # @fgadoc:jtbd View a past meeting summary
+            define viewer: [user:*] or writer or auditor or invitee from past_meeting_for_participant_view or attendee from past_meeting_for_attendee_view or host from past_meeting_for_host_view
+
         type vote
           relations
             define committee: [committee]

--- a/charts/lfx-platform/templates/openfga/model.yaml
+++ b/charts/lfx-platform/templates/openfga/model.yaml
@@ -301,6 +301,21 @@ spec:
             define attendee: [user]
             # @fgadoc:jtbd View a past meeting & its attachments
             define viewer: [user:*] or attendee or invitee or host or organizer or auditor
+            # Per-artifact conditional access — recording
+            define past_meeting_for_participant_recording_view: [v1_past_meeting]
+            define past_meeting_for_attendee_recording_view: [v1_past_meeting]
+            define past_meeting_for_host_recording_view: [v1_past_meeting]
+            define recording_viewer: [user:*] or organizer or auditor or invitee from past_meeting_for_participant_recording_view or attendee from past_meeting_for_attendee_recording_view or host from past_meeting_for_host_recording_view
+            # Per-artifact conditional access — transcript
+            define past_meeting_for_participant_transcript_view: [v1_past_meeting]
+            define past_meeting_for_attendee_transcript_view: [v1_past_meeting]
+            define past_meeting_for_host_transcript_view: [v1_past_meeting]
+            define transcript_viewer: [user:*] or organizer or auditor or invitee from past_meeting_for_participant_transcript_view or attendee from past_meeting_for_attendee_transcript_view or host from past_meeting_for_host_transcript_view
+            # Per-artifact conditional access — AI summary
+            define past_meeting_for_participant_summary_view: [v1_past_meeting]
+            define past_meeting_for_attendee_summary_view: [v1_past_meeting]
+            define past_meeting_for_host_summary_view: [v1_past_meeting]
+            define ai_summary_viewer: [user:*] or organizer or auditor or invitee from past_meeting_for_participant_summary_view or attendee from past_meeting_for_attendee_summary_view or host from past_meeting_for_host_summary_view
 
         # *All relations are as described in `past_meeting_recording`, unless
         # otherwise noted.*

--- a/charts/lfx-platform/templates/openfga/model.yaml
+++ b/charts/lfx-platform/templates/openfga/model.yaml
@@ -324,63 +324,6 @@ spec:
             define past_meeting_for_host_summary_view: [v1_past_meeting]
             define ai_summary_viewer: [user:*] or organizer or auditor or invitee from past_meeting_for_participant_summary_view or attendee from past_meeting_for_attendee_summary_view or host from past_meeting_for_host_summary_view
 
-        # *All relations are as described in `past_meeting_recording`, unless
-        # otherwise noted.*
-        # @fgadoc:collapse v1_past_meeting
-        type v1_past_meeting_recording
-          relations
-            define past_meeting: [v1_past_meeting]
-            define writer: organizer from past_meeting
-            define auditor: auditor from past_meeting
-            define host: host from past_meeting
-            define participant: invitee from past_meeting or attendee from past_meeting
-            # The following "participant access by related meeting" relations are conditional
-            # because they depend on the past meeting artifact_visibility setting. Auditors
-            # and writers do however by default have access to view the recording.
-            define past_meeting_for_participant_view: [v1_past_meeting]
-            define past_meeting_for_attendee_view: [v1_past_meeting]
-            define past_meeting_for_host_view: [v1_past_meeting]
-            # If the artifact_visibility is public, then every user should be a viewer
-            define viewer: [user:*] or writer or auditor or invitee from past_meeting_for_participant_view or attendee from past_meeting_for_attendee_view or host from past_meeting_for_host_view
-
-        # *All relations are as described in `past_meeting_transcript`, unless
-        # otherwise noted.*
-        # @fgadoc:collapse v1_past_meeting
-        type v1_past_meeting_transcript
-          relations
-            define past_meeting: [v1_past_meeting]
-            define writer: organizer from past_meeting
-            define auditor: auditor from past_meeting
-            define host: host from past_meeting
-            define participant: invitee from past_meeting or attendee from past_meeting
-            # The following "participant access by related meeting" relations are conditional
-            # because they depend on the past meeting artifact_visibility setting. Auditors
-            # and writers do however by default have access to view the transcript.
-            define past_meeting_for_participant_view: [v1_past_meeting]
-            define past_meeting_for_attendee_view: [v1_past_meeting]
-            define past_meeting_for_host_view: [v1_past_meeting]
-            # If the artifact_visibility is public, then every user should be a viewer
-            define viewer: [user:*] or writer or auditor or invitee from past_meeting_for_participant_view or attendee from past_meeting_for_attendee_view or host from past_meeting_for_host_view
-
-        # @fgadoc:collapse v1_past_meeting
-        type v1_past_meeting_summary
-          relations
-            define past_meeting: [v1_past_meeting]
-            # @fgadoc:jtbd Update a past meeting summary
-            define writer: organizer from past_meeting
-            define auditor: auditor from past_meeting
-            define host: host from past_meeting
-            define participant: invitee from past_meeting or attendee from past_meeting
-            # The following "participant access by related meeting" relations are conditional
-            # because they depend on the past meeting artifact_visibility setting. Auditors
-            # and writers do however by default have access to view the summary.
-            define past_meeting_for_participant_view: [v1_past_meeting]
-            define past_meeting_for_attendee_view: [v1_past_meeting]
-            define past_meeting_for_host_view: [v1_past_meeting]
-            # If the artifact_visibility is public, then every user should be a viewer
-            # @fgadoc:jtbd View a past meeting summary
-            define viewer: [user:*] or writer or auditor or invitee from past_meeting_for_participant_view or attendee from past_meeting_for_attendee_view or host from past_meeting_for_host_view
-
         type vote
           relations
             define committee: [committee]


### PR DESCRIPTION
## Summary

Adds `recording_viewer`, `transcript_viewer`, and `ai_summary_viewer` relations to the `v1_past_meeting` FGA type. Each is backed by three self-referential `past_meeting_for_*_view` reference relations that delegate to the existing `host`/`attendee`/`invitee` roles.

This unblocks the companion meeting-service change ([linuxfoundation/lfx-v2-meeting-service#146](https://github.com/linuxfoundation/lfx-v2-meeting-service/pull/146)) which writes FGA tuples using these new relations when a past meeting's `recording_access`, `transcript_access`, or `ai_summary_access` is set.

> **Deploy order:** This helm change should be deployed before or simultaneously with the meeting-service PR, as the service will start writing tuples using these relation names.

## Ticket

[LFXV2-1505](https://linuxfoundation.atlassian.net/browse/LFXV2-1505)

🤖 Generated with [Claude Code](https://claude.ai/code)

[LFXV2-1505]: https://linuxfoundation.atlassian.net/browse/LFXV2-1505?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ