### PR TITLE
[LFXV2-1476] feat(fga): split committee viewer into roster_viewer and email_viewer scopes

### DIFF
--- a/charts/lfx-platform/templates/openfga/model.yaml
+++ b/charts/lfx-platform/templates/openfga/model.yaml
@@ -79,14 +79,14 @@ spec:
             define writer: [user] or writer from project
             # @fgadoc:jtbd View committee settings
             define auditor: [user, team#member] or writer or auditor from project or meeting_coordinator from project
-            # @fgadoc:jtbd View committee details (name, description, type), invites & resources
+            # @fgadoc:jtbd View committee details, members, invites & resources
             define viewer: [user:*] or member or auditor
-            # set this relation to "self" to enable member access to the roster and emails
+            # set this relation to "self" to enable member access to the roster
             define committee_for_member_roster_access: [committee]
-            # @fgadoc:jtbd View committee member names & roles
+            # set this relation to "self" to enable member access to email addresses
+            define committee_for_member_email_access: [committee]
             define roster_viewer: [user:*] or auditor or member from committee_for_member_roster_access
-            # @fgadoc:jtbd View committee member email addresses
-            define email_viewer: auditor or member from committee_for_member_roster_access
+            define email_viewer: auditor or member from committee_for_member_email_access
 
         # @fgadoc:alias Groups.io Service
         type groupsio_service

--- a/charts/lfx-platform/templates/openfga/model.yaml
+++ b/charts/lfx-platform/templates/openfga/model.yaml
@@ -24,7 +24,7 @@ spec:
 */}}
     - version:
         major: 10
-        minor: 1
+        minor: 2
         patch: 0
       authorizationModel: |
         model
@@ -79,8 +79,14 @@ spec:
             define writer: [user] or writer from project
             # @fgadoc:jtbd View committee settings
             define auditor: [user, team#member] or writer or auditor from project or meeting_coordinator from project
-            # @fgadoc:jtbd View committee details, members, invites & resources
+            # @fgadoc:jtbd View committee details (name, description, type), invites & resources
             define viewer: [user:*] or member or auditor
+            # set this relation to "self" to enable member access to the roster and emails
+            define committee_for_member_roster_access: [committee]
+            # @fgadoc:jtbd View committee member names & roles
+            define roster_viewer: [user:*] or auditor or member from committee_for_member_roster_access
+            # @fgadoc:jtbd View committee member email addresses
+            define email_viewer: auditor or member from committee_for_member_roster_access
 
         # @fgadoc:alias Groups.io Service
         type groupsio_service


### PR DESCRIPTION
## Summary

- Splits the `committee` type's single `viewer` relation into granular scopes for member roster and email access
- Adds `roster_viewer` relation: grants access to member names & roles (no emails); exposed publicly on `[user:*]` or via auditor/conditional member access
- Adds `email_viewer` relation: gates member email address access on `auditor` or conditional member access
- Adds `committee_for_member_roster_access: [committee]` self-referential pointer — analogous to `vote_for_participant_result_access` — enabling per-committee opt-in for members to view each other's roster and emails
- Bumps model minor version from 10.1.0 → 10.2.0

## Ticket

[LFXV2-1476](https://linuxfoundation.atlassian.net/browse/LFXV2-1476)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[LFXV2-1476]: https://linuxfoundation.atlassian.net/browse/LFXV2-1476?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ