### PR TITLE
Add missing relations to vote_response FGA type

### DIFF
--- a/charts/lfx-platform/templates/openfga/model.yaml
+++ b/charts/lfx-platform/templates/openfga/model.yaml
@@ -24,7 +24,7 @@ spec:
 */}}
     - version:
         major: 10
-        minor: 1
+        minor: 2
         patch: 0
       authorizationModel: |
         model

--- a/charts/lfx-platform/templates/openfga/model.yaml
+++ b/charts/lfx-platform/templates/openfga/model.yaml
@@ -381,14 +381,15 @@ spec:
         type vote_response
           relations
             define vote: [vote]
+            define project: [project]
             # owner is the user who cast this response
             # @fgadoc:alias Voter
             # @fgadoc:jtbd Update your vote response
             define owner: [user]
-            # we don't need to create a "writer" relation that is defined as just "owner":
-            # we just use the "owner" relation in our access checks!
+            define writer: [user] or owner
             # @fgadoc:jtbd View a vote response
             define auditor: owner or auditor from vote
+            define viewer: [user, user:*] or auditor
 
         type survey
           relations

--- a/charts/lfx-platform/templates/openfga/model.yaml
+++ b/charts/lfx-platform/templates/openfga/model.yaml
@@ -24,7 +24,7 @@ spec:
 */}}
     - version:
         major: 10
-        minor: 2
+        minor: 3
         patch: 0
       authorizationModel: |
         model


### PR DESCRIPTION
## Summary

Adds `project`, `writer`, and `viewer` relations to the `vote_response` OpenFGA type to match what the voting-service sends via `lfx.fga-sync.update_access`.

## Problem

`vote_response` was missing three relations that the voting-service writes as FGA tuples:

| Relation | Error |
|---|---|
| `vote_response#project` | `relation 'vote_response#project' not found` |
| `vote_response#viewer` | `relation 'vote_response#viewer' not found` |
| `vote_response#writer` | `relation 'vote_response#writer' not found` |

This caused **2,658 failed batch writes per 24h** in production. The entire batch failed, leaving affected `vote_response` objects with no FGA tuples.

## Change

```diff
 type vote_response
   relations
     define vote: [vote]
+    define project: [project]
     # owner is the user who cast this response
     define owner: [user]
-    # we don't need to create a "writer" relation that is defined as just "owner":
-    # we just use the "owner" relation in our access checks!
+    define writer: [user] or owner
     define auditor: owner or auditor from vote
+    define viewer: [user:*, user] or auditor
```

Consistent with the `vote` and `survey` type patterns.

## Related

- LFXV2-1555 — this issue
- LFXV2-1554 — fga-sync batch write retry fix (handles validation errors gracefully until this model change is deployed)
- linuxfoundation/lfx-v2-fga-sync#44 — retry logic in fga-sync

Closes LFXV2-1555