### PR TITLE
Add executive_director relation to project FGA type

### DIFF
--- a/charts/lfx-platform/templates/openfga/model.yaml
+++ b/charts/lfx-platform/templates/openfga/model.yaml
@@ -24,7 +24,7 @@ spec:
 */}}
     - version:
         major: 10
-        minor: 1
+        minor: 2
         patch: 0
       authorizationModel: |
         model

--- a/charts/lfx-platform/templates/openfga/model.yaml
+++ b/charts/lfx-platform/templates/openfga/model.yaml
@@ -59,10 +59,15 @@ spec:
             # @fgadoc:jtbd View project membership tiers
             # @fgadoc:jtbd View project memberships & member companies
             # @fgadoc:jtbd View project membership key contacts
-            define auditor: [user, team#member] or writer or auditor from parent
+            define auditor: [user, team#member] or executive_director or writer or auditor from parent
+            # The meeting_coordinator relation identifies a user who can manage any meeting
+            # for a given project.
             define meeting_coordinator: [user]
             # @fgadoc:jtbd Create project meetings
             define meetings_creator: writer or meeting_coordinator
+            # executive_director identifies a user with the executive director role for a project,
+            # as assigned by the project-service. executive_directors are auditors of the project.
+            define executive_director: [user]
             # @fgadoc:jtbd View a project
             # @fgadoc:jtbd View project meeting count
             define viewer: [user:*] or auditor or meeting_coordinator


### PR DESCRIPTION
## Summary

Adds `executive_director` as a named user relation on the `project` OpenFGA type and includes it in `auditor`, granting executive directors auditor → viewer access transitively.

## Problem

The project-service assigns `executive_director` tuples to project objects, but this relation didn't exist in the model:

```
Invalid tuple 'project:UUID#executive_director@user:auth0|ajoshipura'.
Reason: relation 'project#executive_director' not found
```

This caused **51 failed batch writes per reconciliation cycle**, leaving affected projects with no FGA tuples (no `viewer`, no `parent`).

## Change

```diff
 type project
   relations
     define parent: [project]
     define owner: [team#member] or owner from parent
     define writer: [user] or owner or writer from parent
-    define auditor: [user, team#member] or writer or auditor from parent
+    define auditor: [user, team#member] or executive_director or writer or auditor from parent
     # The meeting_coordinator relation identifies a user who can manage any meeting
     # for a given project.
     define meeting_coordinator: [user]
+    # executive_director identifies a user with the executive director role for a project,
+    # as assigned by the project-service. executive_directors are auditors of the project.
+    define executive_director: [user]
     define viewer: [user:*] or auditor or auditor from parent
```

## Related

- LFXV2-1556 — this issue
- LFXV2-1554 — fga-sync batch write retry fix
- LFXV2-1555 / PR #131 — vote_response missing relations (same class of bug)

Closes LFXV2-1556