### PR TITLE
chore: helm dependency update (fga-sync 0.3.1)

### DIFF
--- a/charts/lfx-platform/Chart.lock
+++ b/charts/lfx-platform/Chart.lock
@@ -19,7 +19,7 @@ dependencies:
   version: 0.25.2
 - name: authelia
   repository: https://charts.authelia.com
-  version: 0.10.58
+  version: 0.10.59
 - name: nack
   repository: https://nats-io.github.io/k8s/helm/charts/
   version: 0.29.2
@@ -37,19 +37,19 @@ dependencies:
   version: v0.18.0
 - name: lfx-v2-query-service
   repository: oci://ghcr.io/linuxfoundation/lfx-v2-query-service/chart
-  version: 0.4.16
+  version: 0.4.19
 - name: lfx-v2-project-service
   repository: oci://ghcr.io/linuxfoundation/lfx-v2-project-service/chart
-  version: 0.6.6
+  version: 0.6.7
 - name: lfx-v2-fga-sync
   repository: oci://ghcr.io/linuxfoundation/lfx-v2-fga-sync/chart
-  version: 0.3.0
+  version: 0.3.1
 - name: lfx-v2-access-check
   repository: oci://ghcr.io/linuxfoundation/lfx-v2-access-check/chart
   version: 0.3.1
 - name: lfx-v2-indexer-service
   repository: oci://ghcr.io/linuxfoundation/lfx-v2-indexer-service/chart
-  version: 0.4.19
+  version: 0.4.20
 - name: lfx-v2-committee-service
   repository: oci://ghcr.io/linuxfoundation/lfx-v2-committee-service/chart
   version: 0.2.32
@@ -58,15 +58,15 @@ dependencies:
   version: 0.8.0
 - name: lfx-v2-mailing-list-service
   repository: oci://ghcr.io/linuxfoundation/lfx-v2-mailing-list-service/chart
-  version: 0.4.11
+  version: 0.4.12
 - name: lfx-v2-auth-service
   repository: oci://ghcr.io/linuxfoundation/lfx-v2-auth-service/chart
   version: 0.4.5
 - name: lfx-v2-voting-service
   repository: oci://ghcr.io/linuxfoundation/lfx-v2-voting-service/chart
-  version: 0.2.6
+  version: 0.2.8
 - name: lfx-v2-survey-service
   repository: oci://ghcr.io/linuxfoundation/lfx-v2-survey-service/chart
   version: 0.2.6
-digest: sha256:6b7efc9eea3d06e6e901e73134c368d653c6cfde6229946a9732e0dab702cae1
-generated: "2026-04-21T10:14:30.019842-07:00"
+digest: sha256:0483caed34edfc8416003c21e4cffa0df38a5b808f8963e06be1a5a6f92f9fb7
+generated: "2026-05-04T12:48:56.717773-07:00"


### PR DESCRIPTION
## Summary

- Bumps `lfx-v2-fga-sync` subchart from `0.3.0` → `0.3.1`
- Also pulls in latest patch releases for other subcharts within their existing pinned ranges (authelia, query-service, project-service, indexer-service, mailing-list-service, voting-service)

## fga-sync 0.3.1 changes

Preserves team member grant tuples (e.g. `team:myteam#member`) during object sync — previously a resource-service `update_access` event would silently delete any team-based `owner`/`auditor` grants written out-of-band. See [LFXV2-1635](https://linuxfoundation.atlassian.net/browse/LFXV2-1635) and [lfx-v2-fga-sync#48](https://github.com/linuxfoundation/lfx-v2-fga-sync/pull/48).

## Next step

After merge, bump `targetRevision` for `lfx-platform` in `lfx-v2-argocd` and update the fga-sync image tag to `0.3.1` in staging/prod values.

🤖 Generated with [GitHub Copilot](https://github.com/features/copilot) (via OpenCode)

[LFXV2-1635]: https://linuxfoundation.atlassian.net/browse/LFXV2-1635?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ