### PR TITLE
[LFXV2-1768] feat: add lfx-v2-email-service to lfx-platform umbrella chart

### DIFF
--- a/charts/lfx-platform/Chart.lock
+++ b/charts/lfx-platform/Chart.lock
@@ -31,42 +31,42 @@ dependencies:
   version: 2.1.0
 - name: cert-manager
   repository: https://charts.jetstack.io
-  version: v1.18.3
+  version: v1.18.6
 - name: trust-manager
   repository: https://charts.jetstack.io
   version: v0.18.0
 - name: lfx-v2-query-service
   repository: oci://ghcr.io/linuxfoundation/lfx-v2-query-service/chart
-  version: 0.4.19
+  version: 0.4.20
 - name: lfx-v2-project-service
   repository: oci://ghcr.io/linuxfoundation/lfx-v2-project-service/chart
-  version: 0.6.7
+  version: 0.6.11
 - name: lfx-v2-fga-sync
   repository: oci://ghcr.io/linuxfoundation/lfx-v2-fga-sync/chart
-  version: 0.3.1
+  version: 0.3.2
 - name: lfx-v2-access-check
   repository: oci://ghcr.io/linuxfoundation/lfx-v2-access-check/chart
-  version: 0.3.1
+  version: 0.3.3
 - name: lfx-v2-indexer-service
   repository: oci://ghcr.io/linuxfoundation/lfx-v2-indexer-service/chart
-  version: 0.4.20
+  version: 0.4.22
 - name: lfx-v2-committee-service
   repository: oci://ghcr.io/linuxfoundation/lfx-v2-committee-service/chart
-  version: 0.2.32
+  version: 0.2.34
 - name: lfx-v2-meeting-service
   repository: oci://ghcr.io/linuxfoundation/lfx-v2-meeting-service/chart
   version: 0.8.0
 - name: lfx-v2-mailing-list-service
   repository: oci://ghcr.io/linuxfoundation/lfx-v2-mailing-list-service/chart
-  version: 0.4.12
+  version: 0.4.13
 - name: lfx-v2-auth-service
   repository: oci://ghcr.io/linuxfoundation/lfx-v2-auth-service/chart
   version: 0.4.5
 - name: lfx-v2-voting-service
   repository: oci://ghcr.io/linuxfoundation/lfx-v2-voting-service/chart
-  version: 0.2.8
+  version: 0.2.9
 - name: lfx-v2-survey-service
   repository: oci://ghcr.io/linuxfoundation/lfx-v2-survey-service/chart
-  version: 0.2.6
-digest: sha256:0483caed34edfc8416003c21e4cffa0df38a5b808f8963e06be1a5a6f92f9fb7
-generated: "2026-05-04T12:48:56.717773-07:00"
+  version: 0.2.8
+digest: sha256:7da95283e3a80fc22ab6abbccf3b92e757b8a11e216b6a2dd743be5c6d9ef7ac
+generated: "2026-05-13T08:45:12.863701-07:00"

--- a/charts/lfx-platform/Chart.lock
+++ b/charts/lfx-platform/Chart.lock
@@ -52,7 +52,7 @@ dependencies:
   version: 0.4.22
 - name: lfx-v2-committee-service
   repository: oci://ghcr.io/linuxfoundation/lfx-v2-committee-service/chart
-  version: 0.2.34
+  version: 0.2.35
 - name: lfx-v2-meeting-service
   repository: oci://ghcr.io/linuxfoundation/lfx-v2-meeting-service/chart
   version: 0.8.0
@@ -68,5 +68,8 @@ dependencies:
 - name: lfx-v2-survey-service
   repository: oci://ghcr.io/linuxfoundation/lfx-v2-survey-service/chart
   version: 0.2.8
-digest: sha256:7da95283e3a80fc22ab6abbccf3b92e757b8a11e216b6a2dd743be5c6d9ef7ac
-generated: "2026-05-13T08:45:12.863701-07:00"
+- name: lfx-v2-email-service
+  repository: oci://ghcr.io/linuxfoundation/lfx-v2-email-service/chart
+  version: 0.1.0
+digest: sha256:2d2a677cbde8e03507df0cb6f8d6c22de8519cb18a9edd3f7263737a26a382f0
+generated: "2026-05-14T11:33:47.131522-07:00"

--- a/charts/lfx-platform/Chart.yaml
+++ b/charts/lfx-platform/Chart.yaml
@@ -101,3 +101,7 @@ dependencies:
     repository: oci://ghcr.io/linuxfoundation/lfx-v2-survey-service/chart
     version: ~0.2.3
     condition: lfx-v2-survey-service.enabled
+  - name: lfx-v2-email-service
+    repository: oci://ghcr.io/linuxfoundation/lfx-v2-email-service/chart
+    version: ~0.1.0
+    condition: lfx-v2-email-service.enabled

--- a/charts/lfx-platform/Chart.yaml
+++ b/charts/lfx-platform/Chart.yaml
@@ -101,3 +101,7 @@ dependencies:
     repository: oci://ghcr.io/linuxfoundation/lfx-v2-survey-service/chart
     version: ~0.2.3
     condition: lfx-v2-survey-service.enabled
+  - name: lfx-v2-email-service
+    repository: oci://ghcr.io/linuxfoundation/lfx-v2-email-service/chart
+    version: ~0.0.1
+    condition: lfx-v2-email-service.enabled

--- a/charts/lfx-platform/Chart.yaml
+++ b/charts/lfx-platform/Chart.yaml
@@ -101,7 +101,3 @@ dependencies:
     repository: oci://ghcr.io/linuxfoundation/lfx-v2-survey-service/chart
     version: ~0.2.3
     condition: lfx-v2-survey-service.enabled
-  - name: lfx-v2-email-service
-    repository: oci://ghcr.io/linuxfoundation/lfx-v2-email-service/chart
-    version: ~0.0.1
-    condition: lfx-v2-email-service.enabled

--- a/charts/lfx-platform/values.yaml
+++ b/charts/lfx-platform/values.yaml
@@ -701,6 +701,17 @@ lfx-v2-mailing-list-service:
   externalSecretsOperator:
     enabled: false
 
+lfx-v2-email-service:
+  replicaCount: 1
+  enabled: true
+  lfx:
+    domain: k8s.orb.local
+
+  # External Secrets Operator is disabled because we can't get secrets from AWS Secrets Manager in local development.
+  # Instead, create the Kubernetes secret manually. See the chart README for instructions.
+  externalSecretsOperator:
+    enabled: false
+
 lfx-v2-auth-service:
   replicaCount: 1
   enabled: true

--- a/charts/lfx-platform/values.yaml
+++ b/charts/lfx-platform/values.yaml
@@ -725,4 +725,3 @@ lfx-v2-auth-service:
         value: lfx-platform-authelia
       AUTHELIA_SECRET_NAME:
         value: authelia-users
-

--- a/charts/lfx-platform/values.yaml
+++ b/charts/lfx-platform/values.yaml
@@ -725,3 +725,10 @@ lfx-v2-auth-service:
         value: lfx-platform-authelia
       AUTHELIA_SECRET_NAME:
         value: authelia-users
+
+lfx-v2-email-service:
+  replicaCount: 1
+  enabled: true
+  app:
+    emailEnabled: false
+    smtpSecretName: "lfx-v2-email-service-smtp"

--- a/charts/lfx-platform/values.yaml
+++ b/charts/lfx-platform/values.yaml
@@ -726,9 +726,3 @@ lfx-v2-auth-service:
       AUTHELIA_SECRET_NAME:
         value: authelia-users
 
-lfx-v2-email-service:
-  replicaCount: 1
-  enabled: true
-  app:
-    emailEnabled: false
-    smtpSecretName: "lfx-v2-email-service-smtp"


### PR DESCRIPTION
## Summary
- Adds `lfx-v2-email-service` as a new chart dependency in `charts/lfx-platform/Chart.yaml` at version `~0.1.0` from `oci://ghcr.io/linuxfoundation/lfx-v2-email-service/chart`
- Adds default local development values for `lfx-v2-email-service` in `values.yaml` (enabled, 1 replica, local domain, ESO disabled)
- Regenerates `charts/lfx-platform/Chart.lock` to include `lfx-v2-email-service v0.1.0` and pick up version bumps for several existing dependencies

## Ticket

[LFXV2-1768](https://linuxfoundation.atlassian.net/browse/LFXV2-1768)

🤖 Generated with [Claude Code](https://claude.ai/code)

[LFXV2-1768]: https://linuxfoundation.atlassian.net/browse/LFXV2-1768?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ