### PR TITLE
add missing api docs

### DIFF
--- a/charts/lfx-platform/values.yaml
+++ b/charts/lfx-platform/values.yaml
@@ -59,6 +59,8 @@ lfx:
       - "_access-check/openapi3.yaml"
       - "_voting/openapi3.yaml"
       - "_survey/openapi3.yaml"
+      - "_groupsio/openapi3.yaml"
+      - "_memberships/openapi3.yaml"
 
   # Tells rulesets to use the oidc_contextualizer, needed for
   # local dev with authelia


### PR DESCRIPTION
mailing lists (groupsio) and membership docs were missing from the defaults.

Issue: LFXV2-1782