### PR TITLE
feat: add lfx-v2-email-service chart dependency at v0.1.0

### DIFF
--- a/charts/lfx-platform/Chart.yaml
+++ b/charts/lfx-platform/Chart.yaml
@@ -101,3 +101,7 @@ dependencies:
     repository: oci://ghcr.io/linuxfoundation/lfx-v2-survey-service/chart
     version: ~0.2.3
     condition: lfx-v2-survey-service.enabled
+  - name: lfx-v2-email-service
+    repository: oci://ghcr.io/linuxfoundation/lfx-v2-email-service/chart
+    version: ~0.1.0
+    condition: lfx-v2-email-service.enabled

--- a/charts/lfx-platform/values.yaml
+++ b/charts/lfx-platform/values.yaml
@@ -703,6 +703,17 @@ lfx-v2-mailing-list-service:
   externalSecretsOperator:
     enabled: false
 
+lfx-v2-email-service:
+  replicaCount: 1
+  enabled: true
+  lfx:
+    domain: k8s.orb.local
+
+  # External Secrets Operator is disabled because we can't get secrets from AWS Secrets Manager in local development.
+  # Instead, create the Kubernetes secret manually. See the chart README for instructions.
+  externalSecretsOperator:
+    enabled: false
+
 lfx-v2-auth-service:
   replicaCount: 1
   enabled: true


### PR DESCRIPTION
## Summary
- Adds `lfx-v2-email-service` as a new chart dependency in `charts/lfx-platform/Chart.yaml` at version `~0.1.0` from `oci://ghcr.io/linuxfoundation/lfx-v2-email-service/chart`
- Adds default local development values for `lfx-v2-email-service` in `values.yaml` (enabled, 1 replica, local domain, ESO disabled)

🤖 Generated with [Claude Code](https://claude.ai/code)