### PR TITLE
feat(swagger-ui): expose configurable resources for swagger-ui and spec-merger containers

### DIFF
--- a/charts/lfx-platform/templates/swagger_ui/deployment.yaml
+++ b/charts/lfx-platform/templates/swagger_ui/deployment.yaml
@@ -30,13 +30,10 @@ spec:
               mountPath: /shared
             - name: merge-script
               mountPath: /scripts
+          {{- with .Values.lfx.swagger_ui.merger.resources }}
           resources:
-            requests:
-              memory: "64Mi"
-              cpu: "100m"
-            limits:
-              memory: "128Mi"
-              cpu: "200m"
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
       containers:
         - name: swagger-ui
           image: {{ .Values.lfx.swagger_ui.image }}:{{ .Values.lfx.swagger_ui.tag }}
@@ -51,13 +48,10 @@ spec:
               value: "spec/openapi-merged.yaml"
             - name: OAUTH_CLIENT_ID
               value: {{ .Values.lfx.swagger_ui.auth.clientId | quote }}
+          {{- with .Values.lfx.swagger_ui.resources }}
           resources:
-            requests:
-              memory: "64Mi"
-              cpu: "100m"
-            limits:
-              memory: "128Mi"
-              cpu: "200m"
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           readinessProbe:
             httpGet:
               path: /

--- a/charts/lfx-platform/values.yaml
+++ b/charts/lfx-platform/values.yaml
@@ -42,9 +42,23 @@ lfx:
     enabled: true
     image: swaggerapi/swagger-ui
     tag: latest
+    resources:
+      requests:
+        cpu: "100m"
+        memory: "64Mi"
+      limits:
+        cpu: "200m"
+        memory: "128Mi"
     merger:
       image: node
       tag: 24-alpine
+      resources:
+        requests:
+          cpu: "100m"
+          memory: "64Mi"
+        limits:
+          cpu: "200m"
+          memory: "128Mi"
     auth:
       enabled: true
       domain: "https://auth.k8s.orb.local"


### PR DESCRIPTION
Adds `resources` fields to `values.yaml` for the swagger-ui component — one for the swagger-ui container and a separate one for the spec-merger init container — so CPU and memory requests/limits can be configured independently per environment. Defaults match the previously hardcoded values, so existing deployments are unaffected.

Jira: [LFXV2-1857](https://linuxfoundation.atlassian.net/browse/LFXV2-1857)

[LFXV2-1857]: https://linuxfoundation.atlassian.net/browse/LFXV2-1857?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ