### PR TITLE
feat(openfga): grant b2b_org auditor access to key contacts (LFXV2-1853)

### DIFF
--- a/charts/lfx-platform/templates/openfga/model.yaml
+++ b/charts/lfx-platform/templates/openfga/model.yaml
@@ -27,8 +27,8 @@ spec:
 */}}
     - version:
         major: 13
-        minor: 1
-        patch: 0
+        minor: 0
+        patch: 1
       authorizationModel: |
         model
           schema 1.1

--- a/charts/lfx-platform/templates/openfga/model.yaml
+++ b/charts/lfx-platform/templates/openfga/model.yaml
@@ -27,7 +27,7 @@ spec:
 */}}
     - version:
         major: 13
-        minor: 0
+        minor: 1
         patch: 0
       authorizationModel: |
         model
@@ -365,7 +365,7 @@ spec:
             define global_org_admin: [team#member]
             define owner: [user]
             define writer: [user] or owner or global_org_admin
-            define auditor: [user, team#member] or writer
+            define auditor: [user, team#member] or writer or key_contact from membership
             # parent is included to model company subsidiaries (a b2b_org may have a
             # parent b2b_org in Salesforce). It is not yet used to propagate access
             # control — it is recorded here for future use only.


### PR DESCRIPTION
## Summary

- Adds `or key_contact from membership` to the `b2b_org#auditor` relation in the OpenFGA authorization model
- A key contact on a `project_membership` rooted on a `b2b_org` now automatically resolves to `auditor` on that org, enabling read access
- Bumps model version **13.0.0 → 13.1.0** (minor — new relation clause added, no existing tuples affected)

### Change

```diff
- define auditor: [user, team#member] or writer
+ define auditor: [user, team#member] or writer or key_contact from membership
```

`key_contact` was already declared on `b2b_org` via `key_contact from membership` but was not wired into `auditor`. This PR closes that gap.

---

## Future scope — one-level parent/child cascade (separate ticket)

The following design is **not** in this PR. It is captured here so the rationale survives for the follow-up ticket.

**Requirement:** A user with `writer` or `auditor` on Org X should also get `auditor` (view-only) access on X's **direct parent** and **direct children** — one hop only. Grandparents, grandchildren, and siblings are out of scope. Writer (edit) access stays scoped strictly to X.

### Proposed model change

```
type b2b_org
  relations
    define global_org_admin: [team#member]
    define owner: [user]
    define writer: [user] or owner or global_org_admin
    # Non-recursive helper — direct assignments + writer chain on THIS org only.
    # Used as the cascade source so `from parent` / `from child` walks exactly one hop.
    define direct_auditor: [user, team#member] or writer
    define auditor: direct_auditor
                    or direct_auditor from parent
                    or direct_auditor from child
                    or key_contact from membership
    define parent: [b2b_org]
    define child: [b2b_org]
    define membership: [project_membership]
    define key_contact: key_contact from membership
```

**Why `direct_auditor`:** OpenFGA's `auditor from parent` is naturally transitive — it walks the entire ancestor chain. Routing the cascade through a non-recursive helper (`direct_auditor` has no `from parent` / `from child` clauses) breaks the recursion so traversal stops after exactly one hop.

### Diagram 1 — view (auditor) cascade for user U assigned on Org A

```mermaid
graph TD
    G["Grandparent G"]
    P["Parent P"]
    A["Org A<br/>(U assigned here)"]
    B["Sibling B"]
    C1["Child C1"]
    C2["Child C2"]
    GC["Grandchild GC"]

    G --> P
    P --> A
    P --> B
    A --> C1
    A --> C2
    C1 --> GC

    style A fill:#cce5ff,stroke:#004085,stroke-width:3px,color:#000
    style P fill:#d4edda,stroke:#155724,stroke-width:2px,color:#000
    style C1 fill:#d4edda,stroke:#155724,stroke-width:2px,color:#000
    style C2 fill:#d4edda,stroke:#155724,stroke-width:2px,color:#000
    style G fill:#f8d7da,stroke:#721c24,stroke-width:1px,color:#000
    style B fill:#f8d7da,stroke:#721c24,stroke-width:1px,color:#000
    style GC fill:#f8d7da,stroke:#721c24,stroke-width:1px,color:#000
```

| Colour | Meaning | Orgs |
|---|---|---|
| Blue | Home org — U is assigned here | A |
| Green | View access via one-level cascade | P (direct parent), C1 / C2 (direct children) |
| Red | No access — outside one-level scope | G (grandparent, 2 hops), B (sibling, 2 hops via P), GC (grandchild, 2 hops) |

### Diagram 2 — edit (writer) scope

```mermaid
graph TD
    G["Grandparent G<br/>no access"]
    P["Parent P<br/>VIEW only"]
    A["Org A<br/>(U is writer here)<br/>VIEW + EDIT"]
    B["Sibling B<br/>no access"]
    C["Child C<br/>VIEW only"]

    G --> P
    P --> A
    P --> B
    A --> C

    style A fill:#cce5ff,stroke:#004085,stroke-width:3px,color:#000
    style P fill:#fff3cd,stroke:#856404,stroke-width:2px,color:#000
    style C fill:#fff3cd,stroke:#856404,stroke-width:2px,color:#000
    style G fill:#f8d7da,stroke:#721c24,stroke-width:1px,color:#000
    style B fill:#f8d7da,stroke:#721c24,stroke-width:1px,color:#000
```

Writer does not cascade — only A is editable. The one-level VIEW cascade still applies.

### Diagram 3 — how `auditor` is computed (future model)

```mermaid
graph LR
    A["auditor on Org X"] -->|or| B["direct_auditor on X"]
    A -->|or| C["direct_auditor from X.parent<br/>(one hop up)"]
    A -->|or| D["direct_auditor from X.child<br/>(one hop down)"]
    A -->|or| E["key_contact from X.membership"]

    B -->|or| F["writer on X"]
    B -->|or| G["user / team directly<br/>assigned direct_auditor"]

    F -->|or| H["owner on X"]
    F -->|or| I["global_org_admin on X"]
    F -->|or| J["user directly<br/>assigned writer"]

    style A fill:#cce5ff,stroke:#004085,color:#000
    style B fill:#d4edda,stroke:#155724,color:#000
    style C fill:#d4edda,stroke:#155724,color:#000
    style D fill:#d4edda,stroke:#155724,color:#000
    style E fill:#d4edda,stroke:#155724,color:#000
```

`direct_auditor` has no `from parent` / `from child` clauses — cascade stops after exactly one hop in each direction.

### Diagram 4 — tuple write pattern on reparenting (member-service)

```mermaid
sequenceDiagram
    participant MS as member-service
    participant SF as Salesforce
    participant NATS as NATS (fga-sync)

    Note over MS: b2b_org reparent: A.parent OldP → NewP

    MS->>SF: Fetch children of OldP (minus A)
    MS->>SF: Fetch children of NewP (plus A)

    MS->>NATS: update_access on b2b_org:A<br/>refs={parent: ["b2b_org:NewP"]}
    MS->>NATS: update_access on b2b_org:NewP<br/>refs={child: [full list + A]}
    MS->>NATS: update_access on b2b_org:OldP<br/>refs={child: [full list − A]}
```

### Coordination cost (why deferred)

- member-service must emit `child` tuples in lockstep with `parent` on every b2b_org reparenting (up to 3 `update_access` messages per write)
- Requires a new `FetchChildSFIDsByParentSFID` SOQL query + NATS KV cache invalidation in member-service
- Any existing writers of `b2b_org#auditor@user:U` tuples must migrate to `direct_auditor` (since `auditor` becomes computed-only with no direct-type declarations)

---

Jira: LFXV2-1853
Link: https://linuxfoundation.atlassian.net/browse/LFXV2-1853

🤖 Generated with [Claude Code](https://claude.com/claude-code)