### PR TITLE
feat(openfga): LFXV2-1912 — b2b_org hierarchy view cascade via parent/child (v13.0.2)

### DIFF
--- a/charts/lfx-platform/templates/openfga/model.yaml
+++ b/charts/lfx-platform/templates/openfga/model.yaml
@@ -28,7 +28,7 @@ spec:
     - version:
         major: 13
         minor: 0
-        patch: 1
+        patch: 2
       authorizationModel: |
         model
           schema 1.1
@@ -365,15 +365,17 @@ spec:
             define global_org_admin: [team#member]
             define owner: [user]
             define writer: [user] or owner or global_org_admin
-            define auditor: [user, team#member] or writer or key_contact from membership
+            # auditor cascades transitively up and down the hierarchy via parent/child.
+            # writer does NOT cascade — edit scope stays on the directly-assigned org only.
+            define auditor: [user, team#member] or writer or auditor from parent or auditor from child or key_contact from membership
             # parent is included to model company subsidiaries (a b2b_org may have a
-            # parent b2b_org in Salesforce). It is not yet used to propagate access
-            # control — it is recorded here for future use only.
+            # parent b2b_org in Salesforce).
             define parent: [b2b_org]
             # The following are reverse "downward" relations — the parent holds a
             # reference to its children. This is intentional for userset traversal
             # but introduces a cross-type dependency; be wary of cycles if adding
             # further reverse relations that reference b2b_org from child types.
+            define child: [b2b_org]
             define membership: [project_membership]
             define key_contact: key_contact from membership
 


### PR DESCRIPTION
## Summary

Implements the full transitive `auditor` cascade across the `b2b_org` hierarchy, building on the key-contact access added in #141 (LFXV2-1853).

- Add `define child: [b2b_org]` relation on `b2b_org` — the materialised inverse of `parent`, emitted by the member-service whenever a `PUT /b2b_orgs/{uid}` detects a changed `Account.ParentId`
- Extend `auditor` definition to cascade transitively up and down the hierarchy:
  ```
  define auditor: [user, team#member] or writer
                  or auditor from parent   ← walks up
                  or auditor from child    ← walks down
                  or key_contact from membership
  ```
- `writer` does **not** cascade — edit scope stays strictly on the directly-assigned org

## Access cascade examples

Given hierarchy: `Org A` and `Org B` are children of `Org P`.

### writer/auditor on parent → auditor on all children

Tuples: `b2b_org:P.writer@user:U`
- `writer` on P → `auditor` on P (via `define auditor: ... or writer`)
- `auditor from parent` on A, B → resolves through P → U has `auditor` on A and B ✅

### writer/auditor on child → auditor on parent and siblings

Tuples: `b2b_org:A.writer@user:U`, `b2b_org:P.child@b2b_org:A`, `b2b_org:P.child@b2b_org:B`
- `writer` on A → `auditor` on A
- `auditor from child` on P → U has `auditor` on A (a child of P) → U is `auditor` on P ✅
- `auditor from parent` on B → P is B's parent, U is `auditor` on P → U is `auditor` on B ✅

### auditor on child → auditor on parent and siblings

Tuples: `b2b_org:A.auditor@user:U` (direct), `b2b_org:P.child@b2b_org:A`, `b2b_org:P.child@b2b_org:B`, `b2b_org:B.parent@b2b_org:P`
- `auditor from child` on P → U has `auditor` on A (child of P) → U is `auditor` on P ✅
- `auditor from parent` on B → U is `auditor` on P (B's parent) → U is `auditor` on B ✅

### key_contact → auditor on org and full hierarchy (LFXV2-1853 + cascade)

Tuples: `project_membership:M.key_contact@user:U`, `b2b_org:A.membership@project_membership:M`, `b2b_org:P.child@b2b_org:A`
- `key_contact from membership` on A → U is `auditor` on A ✅
- Cascade applies: U is `auditor` on P and siblings of A ✅

## Why full recursion, not one-hop

The PR #141 future-scope section proposed a `direct_auditor` helper to limit traversal to one hop. After requirements review, the business rule is **"view any organization in the connected hierarchy"** — including grandparents, grandchildren, and siblings. Full mutual recursion via `auditor from parent` + `auditor from child` covers the entire connected component. OpenFGA detects cycles, so the P→child→A→parent→P loop terminates cleanly.

## Related

- #141 — LFXV2-1853: key_contact → b2b_org auditor (merged, this PR builds on it)
- lfx-v2-member-service LFXV2-1912: member-service emits `child` FGA tuples on b2b_org reparent

Jira: LFXV2-1912
Link: https://linuxfoundation.atlassian.net/browse/LFXV2-1912