### PR TITLE
[LFXV2-1783] feat: add lfx-v2-invite-service to lfx-platform umbrella chart

### DIFF
--- a/charts/lfx-platform/Chart.lock
+++ b/charts/lfx-platform/Chart.lock
@@ -64,12 +64,15 @@ dependencies:
   version: 0.4.5
 - name: lfx-v2-voting-service
   repository: oci://ghcr.io/linuxfoundation/lfx-v2-voting-service/chart
-  version: 0.2.9
+  version: 0.2.13
 - name: lfx-v2-survey-service
   repository: oci://ghcr.io/linuxfoundation/lfx-v2-survey-service/chart
-  version: 0.2.8
+  version: 0.2.11
 - name: lfx-v2-email-service
   repository: oci://ghcr.io/linuxfoundation/lfx-v2-email-service/chart
   version: 0.1.0
-digest: sha256:2d2a677cbde8e03507df0cb6f8d6c22de8519cb18a9edd3f7263737a26a382f0
-generated: "2026-05-14T11:33:47.131522-07:00"
+- name: lfx-v2-invite-service
+  repository: oci://ghcr.io/linuxfoundation/lfx-v2-invite-service/chart
+  version: 0.1.0
+digest: sha256:44e4ea58f0fc24ac70bd1462ac7d04ab984297b09e20eb2c6bdb3b46eba33ce0
+generated: "2026-05-21T08:57:05.161502-07:00"

--- a/charts/lfx-platform/Chart.yaml
+++ b/charts/lfx-platform/Chart.yaml
@@ -105,3 +105,7 @@ dependencies:
     repository: oci://ghcr.io/linuxfoundation/lfx-v2-email-service/chart
     version: ~0.1.0
     condition: lfx-v2-email-service.enabled
+  - name: lfx-v2-invite-service
+    repository: oci://ghcr.io/linuxfoundation/lfx-v2-invite-service/chart
+    version: ~0.1.0
+    condition: lfx-v2-invite-service.enabled

--- a/charts/lfx-platform/README.md
+++ b/charts/lfx-platform/README.md
@@ -204,6 +204,10 @@ linked documentation for the full set of configuration options.
 | lfx-v2-survey-service       | `lfx-v2-survey-service`       | `true`            | [lfx-v2-survey-service Helm Chart](https://github.com/linuxfoundation/lfx-v2-survey-service/tree/main/charts/lfx-v2-survey-service) |
 | lfx-v2-meeting-service      | `lfx-v2-meeting-service`      | `true`            | [lfx-v2-meeting-service Helm Chart](https://github.com/linuxfoundation/lfx-v2-meeting-service/tree/main/charts/lfx-v2-meeting-service) |
 | lfx-v2-mailing-list-service | `lfx-v2-mailing-list-service` | `true`            | [lfx-v2-mailing-list-service Helm Chart](https://github.com/linuxfoundation/lfx-v2-mailing-list-service/tree/main/charts/lfx-v2-mailing-list-service) |
+| lfx-v2-email-service        | `lfx-v2-email-service`        | `true`            | [lfx-v2-email-service Helm Chart](https://github.com/linuxfoundation/lfx-v2-email-service/tree/main/charts/lfx-v2-email-service) |
+| lfx-v2-invite-service       | `lfx-v2-invite-service`       | `true`            | [lfx-v2-invite-service Helm Chart](https://github.com/linuxfoundation/lfx-v2-invite-service/tree/main/charts/lfx-v2-invite-service) |
+| lfx-v2-email-service        | `lfx-v2-email-service`        | `true`            | [lfx-v2-email-service Helm Chart](https://github.com/linuxfoundation/lfx-v2-email-service/tree/main/charts/lfx-v2-email-service) |
+| lfx-v2-invite-service       | `lfx-v2-invite-service`       | `true`            | [lfx-v2-invite-service Helm Chart](https://github.com/linuxfoundation/lfx-v2-invite-service/tree/main/charts/lfx-v2-invite-service) |
 
 #### Developing a service locally
 

--- a/charts/lfx-platform/README.md
+++ b/charts/lfx-platform/README.md
@@ -206,8 +206,6 @@ linked documentation for the full set of configuration options.
 | lfx-v2-mailing-list-service | `lfx-v2-mailing-list-service` | `true`            | [lfx-v2-mailing-list-service Helm Chart](https://github.com/linuxfoundation/lfx-v2-mailing-list-service/tree/main/charts/lfx-v2-mailing-list-service) |
 | lfx-v2-email-service        | `lfx-v2-email-service`        | `true`            | [lfx-v2-email-service Helm Chart](https://github.com/linuxfoundation/lfx-v2-email-service/tree/main/charts/lfx-v2-email-service) |
 | lfx-v2-invite-service       | `lfx-v2-invite-service`       | `true`            | [lfx-v2-invite-service Helm Chart](https://github.com/linuxfoundation/lfx-v2-invite-service/tree/main/charts/lfx-v2-invite-service) |
-| lfx-v2-email-service        | `lfx-v2-email-service`        | `true`            | [lfx-v2-email-service Helm Chart](https://github.com/linuxfoundation/lfx-v2-email-service/tree/main/charts/lfx-v2-email-service) |
-| lfx-v2-invite-service       | `lfx-v2-invite-service`       | `true`            | [lfx-v2-invite-service Helm Chart](https://github.com/linuxfoundation/lfx-v2-invite-service/tree/main/charts/lfx-v2-invite-service) |
 
 #### Developing a service locally
 

--- a/charts/lfx-platform/values.yaml
+++ b/charts/lfx-platform/values.yaml
@@ -731,20 +731,11 @@ lfx-v2-email-service:
 lfx-v2-invite-service:
   replicaCount: 1
   enabled: true
-  image:
-    pullPolicy: IfNotPresent
-  app:
-    logLevel: debug
-    # Disable secretKeyRef injection for local dev — secret is injected via extraEnv below
-    jwtSecretName: ""
-    selfServeBaseURL: "http://localhost:4200"
-    otel:
-      tracesExporter: "none"
-      metricsExporter: "none"
-      logsExporter: "none"
-    extraEnv:
-      - name: INVITE_JWT_SECRET
-        value: "local-dev-invite-jwt-secret-change-me"
+
+  # External Secrets Operator is disabled because we can't get secrets from AWS Secrets Manager in local development.
+  # Instead, create the Kubernetes secret manually. See the chart README for instructions.
+  externalSecretsOperator:
+    enabled: false
 
 lfx-v2-auth-service:
   replicaCount: 1

--- a/charts/lfx-platform/values.yaml
+++ b/charts/lfx-platform/values.yaml
@@ -728,6 +728,21 @@ lfx-v2-email-service:
   externalSecretsOperator:
     enabled: false
 
+lfx-v2-invite-service:
+  replicaCount: 1
+  enabled: true
+  image:
+    pullPolicy: IfNotPresent
+  app:
+    logLevel: debug
+    # For local dev only — production injects INVITE_JWT_SECRET via extraEnv + secretKeyRef
+    inviteJWTSecret: "local-dev-invite-jwt-secret-change-me"
+    selfServeBaseURL: "http://localhost:4200"
+    otel:
+      tracesExporter: "none"
+      metricsExporter: "none"
+      logsExporter: "none"
+
 lfx-v2-auth-service:
   replicaCount: 1
   enabled: true

--- a/charts/lfx-platform/values.yaml
+++ b/charts/lfx-platform/values.yaml
@@ -735,13 +735,16 @@ lfx-v2-invite-service:
     pullPolicy: IfNotPresent
   app:
     logLevel: debug
-    # For local dev only — production injects INVITE_JWT_SECRET via extraEnv + secretKeyRef
-    inviteJWTSecret: "local-dev-invite-jwt-secret-change-me"
+    # Disable secretKeyRef injection for local dev — secret is injected via extraEnv below
+    jwtSecretName: ""
     selfServeBaseURL: "http://localhost:4200"
     otel:
       tracesExporter: "none"
       metricsExporter: "none"
       logsExporter: "none"
+    extraEnv:
+      - name: INVITE_JWT_SECRET
+        value: "local-dev-invite-jwt-secret-change-me"
 
 lfx-v2-auth-service:
   replicaCount: 1


### PR DESCRIPTION
## Summary

- Adds `lfx-v2-invite-service` as a subchart dependency of the `lfx-platform` umbrella chart (OCI source: `ghcr.io/linuxfoundation/lfx-v2-invite-service/chart ~0.1.0`)
- Adds local-dev defaults in `values.yaml`: `enabled: true`, `replicaCount: 1`

## Ticket

[LFXV2-1783](https://linuxfoundation.atlassian.net/browse/LFXV2-1783)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[LFXV2-1783]: https://linuxfoundation.atlassian.net/browse/LFXV2-1783?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ