### PR TITLE
LFXV2-2232: Add Marketing Ops relations to OpenFGA model

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/charts/lfx-platform/templates/openfga/model.yaml
+++ b/charts/lfx-platform/templates/openfga/model.yaml
@@ -67,13 +67,15 @@ spec:
             define executive_director: [user]
             # marketing_ops identifies the global LF Marketing Ops team (platform admin UI).
             # Tuples are written on ROOT as team#member, matching the owner relation pattern.
-            # marketing_ops from parent cascades to foundation projects via the project parent
-            # chain so RuleSets can check marketing_* relations on the foundation project
-            # object (same as executive_director). Does not cascade to child object types
-            # (committees, meetings, mailing lists, etc.).
+            # marketing_ops from parent cascades down the entire project parent chain
+            # (ROOT → foundations → sub-projects), same as owner from parent, so RuleSets
+            # can check marketing_* relations on any project in the hierarchy.
+            # Does not cascade to child object types (committees, meetings, mailing lists, etc.).
             define marketing_ops: [team#member] or marketing_ops from parent
-            # Marketing capability relations (Marketing Impact, Campaigns). Kept separate to allow
-            # future permission divergence (e.g. campaign_manager restricted to executive_director).
+            # Marketing capability relations (Marketing Impact, Campaigns). Each evaluates
+            # marketing_ops on the same project object; marketing_ops cascades from ROOT via
+            # the parent chain above. Kept separate to allow future permission divergence
+            # (e.g. campaign_manager restricted to executive_director).
             define marketing_dashboard_viewer: executive_director or marketing_ops
             define campaign_viewer: executive_director or marketing_ops
             define campaign_manager: executive_director or marketing_ops

--- a/charts/lfx-platform/templates/openfga/model.yaml
+++ b/charts/lfx-platform/templates/openfga/model.yaml
@@ -27,8 +27,8 @@ spec:
 */}}
     - version:
         major: 14
-        minor: 0
-        patch: 1
+        minor: 1
+        patch: 0
       authorizationModel: |
         model
           schema 1.1
@@ -65,6 +65,18 @@ spec:
             # executive_director identifies a user with the executive director role for a project,
             # as assigned by the project-service. executive_directors are auditors of the project.
             define executive_director: [user]
+            # marketing_ops identifies the global LF Marketing Ops team (platform admin UI).
+            # Tuples are written on ROOT as team#member, matching the owner relation pattern.
+            # marketing_ops from parent cascades to foundation projects via the project parent
+            # chain so RuleSets can check marketing_* relations on the foundation project
+            # object (same as executive_director). Does not cascade to child object types
+            # (committees, meetings, mailing lists, etc.).
+            define marketing_ops: [team#member] or marketing_ops from parent
+            # Marketing capability relations (Marketing Impact, Campaigns). Kept separate to allow
+            # future permission divergence (e.g. campaign_manager restricted to executive_director).
+            define marketing_dashboard_viewer: executive_director or marketing_ops
+            define campaign_viewer: executive_director or marketing_ops
+            define campaign_manager: executive_director or marketing_ops
             # @fgadoc:jtbd View project details & meeting count
             # @fgadoc:jtbd View project links & folders
             # @fgadoc:jtbd View project documents

--- a/charts/lfx-platform/templates/openfga/model.yaml
+++ b/charts/lfx-platform/templates/openfga/model.yaml
@@ -65,20 +65,16 @@ spec:
             # executive_director identifies a user with the executive director role for a project,
             # as assigned by the project-service. executive_directors are auditors of the project.
             define executive_director: [user]
-            # marketing_ops identifies the global LF Marketing Ops team (platform admin UI).
-            # Tuples are written on ROOT as team#member, matching the owner relation pattern.
-            # marketing_ops from parent cascades down the entire project parent chain
-            # (ROOT → foundations → sub-projects), same as owner from parent, so RuleSets
-            # can check marketing_* relations on any project in the hierarchy.
-            # Does not cascade to child object types (committees, meetings, mailing lists, etc.).
+
             define marketing_ops: [team#member] or marketing_ops from parent
-            # Marketing capability relations (Marketing Impact, Campaigns). Each evaluates
-            # marketing_ops on the same project object; marketing_ops cascades from ROOT via
-            # the parent chain above. Kept separate to allow future permission divergence
-            # (e.g. campaign_manager restricted to executive_director).
+
+            # @fgadoc:jtbd View Marketing Impact dashboard
             define marketing_dashboard_viewer: executive_director or marketing_ops
+            # @fgadoc:jtbd View campaigns
             define campaign_viewer: executive_director or marketing_ops
+            # @fgadoc:jtbd Create & manage campaigns
             define campaign_manager: executive_director or marketing_ops
+
             # @fgadoc:jtbd View project details & meeting count
             # @fgadoc:jtbd View project links & folders
             # @fgadoc:jtbd View project documents

--- a/charts/lfx-platform/templates/openfga/model.yaml
+++ b/charts/lfx-platform/templates/openfga/model.yaml
@@ -65,16 +65,10 @@ spec:
             # executive_director identifies a user with the executive director role for a project,
             # as assigned by the project-service. executive_directors are auditors of the project.
             define executive_director: [user]
-
             define marketing_ops: [team#member] or marketing_ops from parent
-
-            # @fgadoc:jtbd View Marketing Impact dashboard
             define marketing_dashboard_viewer: executive_director or marketing_ops
-            # @fgadoc:jtbd View campaigns
             define campaign_viewer: executive_director or marketing_ops
-            # @fgadoc:jtbd Create & manage campaigns
             define campaign_manager: executive_director or marketing_ops
-
             # @fgadoc:jtbd View project details & meeting count
             # @fgadoc:jtbd View project links & folders
             # @fgadoc:jtbd View project documents


### PR DESCRIPTION
## Summary
- Add `executive_director` and global `marketing_ops` relations to the `project` type in the OpenFGA authorization model
- `marketing_ops` uses `[team#member]` (global team admin UI) with `marketing_ops from parent` cascade, matching the `owner` relation pattern
- `marketing_ops from parent` is recursive — cascades down the **full project parent chain** (ROOT → foundations → sub-projects)
- Add marketing capability relations (`marketing_dashboard_viewer`, `campaign_viewer`, `campaign_manager`) for Marketing Impact and Campaign access
- Marketing Ops access is scoped to dedicated `marketing_*` relations only — `viewer` is **not** extended with `marketing_ops`
- Bump authorization model version from **14.0.1** to **14.1.0**

## Context
Part of epic [LFXV2-2231](https://linuxfoundation.atlassian.net/browse/LFXV2-2231) to introduce a global Marketing Ops role for LFX Self Serve.

Platform admins attach a global Marketing Ops **team** on ROOT (`team#member` tuple). `marketing_ops from parent` propagates down the entire project parent chain so RuleSets can check `marketing_*` relations on **any project in the hierarchy** (not ROOT-only checks). Marketing Ops does not cascade to child object types (committees, meetings, mailing lists). Health Metrics and the ED dashboard remain ED-only.

## Test plan
- [x] OpenFGA CLI model validate (`openfga/cli model validate`) returns `is_valid: true`
- [ ] Deploy updated model to dev cluster via platform chart
- [ ] Confirm fga-operator picks up model version 14.1.0
- [ ] Verify existing project access checks are unaffected

Jira: https://linuxfoundation.atlassian.net/browse/LFXV2-2232

[LFXV2-2231]: https://linuxfoundation.atlassian.net/browse/LFXV2-2231?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ