### PR TITLE
feat: add openfga_or_check authorizer for OR-based FGA authorization (LFXV2-2395)

### DIFF
--- a/charts/lfx-platform/values.yaml
+++ b/charts/lfx-platform/values.yaml
@@ -332,6 +332,63 @@ heimdall:
           expressions:
             - expression: |
                 Payload.allowed == true
+      - id: openfga_or_check
+        type: remote
+        config:
+          endpoint: "http://lfx-platform-openfga:8080/stores/${OPENFGA_STORE_ID}/batch-check"
+          values:
+            model_id: ${OPENFGA_AUTH_MODEL_ID}
+          payload: |
+            {
+              "authorization_model_id": "{{ .Values.model_id }}",
+              "checks": [
+                {
+                  "tuple_key": {
+                    "user": {{
+                      list
+                        "user:"
+                        (
+                          eq .Subject.ID "_anonymous"
+                          | ternary
+                            "_anonymous"
+                            (or
+                              .Subject.Attributes.username
+                              (list .Subject.Attributes.client_id "@clients" | join ""))
+                        )
+                      | join "" | quote
+                    }},
+                    "relation": "{{ .Values.relation }}",
+                    "object": "{{ .Values.object }}"
+                  },
+                  "correlation_id": "primary_check"
+                }
+                {{- if .Values.or_object }},
+                {
+                  "tuple_key": {
+                    "user": {{
+                      list
+                        "user:"
+                        (
+                          eq .Subject.ID "_anonymous"
+                          | ternary
+                            "_anonymous"
+                            (or
+                              .Subject.Attributes.username
+                              (list .Subject.Attributes.client_id "@clients" | join ""))
+                        )
+                      | join "" | quote
+                    }},
+                    "relation": "{{ or .Values.or_relation .Values.relation }}",
+                    "object": "{{ .Values.or_object }}"
+                  },
+                  "correlation_id": "secondary_check"
+                }
+                {{- end }}
+              ]
+            }
+          expressions:
+            - expression: |
+                Payload.result.primary_check.allowed || ("secondary_check" in Payload.result && Payload.result.secondary_check.allowed)
     finalizers:
       - id: create_jwt
         type: jwt


### PR DESCRIPTION
## Summary

- Adds a new `openfga_or_check` Heimdall authorizer to the platform mechanisms
- Uses OpenFGA's `/batch-check` endpoint to evaluate two FGA relation checks in a single request
- CEL expression evaluates `primary_check.allowed || secondary_check.allowed`
- All four parameters (`relation`, `object`, `or_relation`, `or_object`) are fully parameterized — reusable for any OR-based authorization need beyond meetings
- The secondary check is omitted from the batch payload when `or_object` is empty, avoiding unnecessary FGA calls

This is a prerequisite for [LFXV2-2395](https://linuxfoundation.atlassian.net/browse/LFXV2-2395), consumed by the meeting-service PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[LFXV2-2395]: https://linuxfoundation.atlassian.net/browse/LFXV2-2395?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ