### PR TITLE
[LFXV2-2402] fix: add committee_invite FGA type and bump model to v14

### DIFF
--- a/charts/lfx-platform/templates/openfga/model.yaml
+++ b/charts/lfx-platform/templates/openfga/model.yaml
@@ -26,9 +26,9 @@ spec:
   @fgadoc:hide and @fgadoc:alias tags are managed manually.
 */}}
     - version:
-        major: 13
+        major: 14
         minor: 0
-        patch: 2
+        patch: 0
       authorizationModel: |
         model
           schema 1.1
@@ -105,6 +105,14 @@ spec:
             define committee_for_member_email_access: [committee]
             define roster_viewer: [user:*] or auditor or member from committee_for_member_roster_access
             define email_viewer: auditor or member from committee_for_member_email_access
+
+        type committee_invite
+          relations
+            define committee: [committee]
+            # The invitee relation identifies the user who was invited to the committee.
+            define invitee: [user]
+            # @fgadoc:jtbd View committee invites
+            define viewer: invitee or auditor from committee
 
         # @fgadoc:alias Groups.io Service
         type groupsio_service

--- a/charts/lfx-platform/templates/openfga/model.yaml
+++ b/charts/lfx-platform/templates/openfga/model.yaml
@@ -111,7 +111,6 @@ spec:
             define committee: [committee]
             # The invitee relation identifies the user who was invited to the committee.
             define invitee: [user]
-            # @fgadoc:jtbd View committee invites
             define viewer: invitee or auditor from committee
 
         # @fgadoc:alias Groups.io Service


### PR DESCRIPTION
## Summary

- Add a new `committee_invite` type to the OpenFGA authorization model so that invite visibility is scoped to the **invitee** and **committee auditors** only, rather than relying on the committee's public `viewer` relation (`user:*`)
- Bump model version `13.0.2` → `14.0.0` (adding a type = major version bump per model versioning guidelines)

## New type

```
type committee_invite
  relations
    define committee: [committee]
    define invitee: [user]
    define viewer: invitee or auditor from committee
```

## Why

The current approach sets `AccessCheckObject = committee:<uid>` on invite index documents. Because `committee.viewer = [user:*] or member or auditor`, invites are effectively public and visible to anyone who queries them — and the invitee (who is not a committee member yet) can't be specifically targeted.

## Deploy ordering

⚠️ This helm change must be deployed **before** the matching committee-service PR (LFXV2-2402) goes live. If the committee-service change is deployed first, access checks against `committee_invite` objects will fail until this model version is active.

## Ticket

[LFXV2-2402](https://linuxfoundation.atlassian.net/browse/LFXV2-2402)

🤖 Generated with [Claude Code](https://claude.ai/code)

[LFXV2-2402]: https://linuxfoundation.atlassian.net/browse/LFXV2-2402?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ