### PR TITLE
docs(openfga): refresh JTBDs, update render-permissions skill, re-render PERMISSIONS.md

### DIFF
--- a/.agents/skills/populate-jtbds/SKILL.md
+++ b/.agents/skills/populate-jtbds/SKILL.md
@@ -129,24 +129,45 @@ the object type.
 
 ## Step 2b — Discover Query Service authorization from indexer contracts
 
-In parallel with or immediately after Step 2, fetch all indexer contract
-documents from GitHub to discover which `object#relation` pairs are enforced
+In parallel with or immediately after Step 2, fetch per-service indexer
+contracts from GitHub to discover which `object#relation` pairs are enforced
 by the Query Service rather than Heimdall.
 
-**Search for all contracts:**
+> **Important:** Do NOT fetch `lfx-v2-indexer-service/docs/indexer-contract.md`.
+> That file describes the generic indexer envelope API, not per-resource access
+> control configuration. It contains no `object_type` sections and will yield
+> zero results.
 
-```text
-filename:indexer-contract.md org:linuxfoundation
+**Discover which services publish contracts:**
+
+Fetch `docs/indexed-data-types.md` from `lfx-v2-query-service`. It lists every
+active resource type and links to the owning service's `docs/indexer-contract.md`.
+Use it to build the list of service repos to fetch from.
+
+```bash
+gh api repos/linuxfoundation/lfx-v2-query-service/contents/docs/indexed-data-types.md \
+  --jq '.content' | python3 -c "import sys,base64; print(base64.b64decode(sys.stdin.read()).decode())"
 ```
 
-Fetch every result's file contents via the GitHub API in a single parallel
-batch (use the `repo` and `path` from each search result).
+**Fetch all per-service contracts in parallel:**
 
-**Parse each contract** to extract, for every resource type section:
+For each owning service identified above (e.g. `lfx-v2-meeting-service`,
+`lfx-v2-committee-service`, `lfx-v2-project-service`, etc.), fetch
+`docs/indexer-contract.md` via the GitHub API in a single parallel batch:
 
-- `object_type` — from the `**Object type:** \`...\`` line
-- `access_check_object` — from the `Access Control (IndexingConfig)` table row
-- `access_check_relation` — from the same table
+```bash
+gh api repos/linuxfoundation/<service-repo>/contents/docs/indexer-contract.md \
+  --jq '.content' | python3 -c "import sys,base64; print(base64.b64decode(sys.stdin.read()).decode())"
+```
+
+**Parse each contract** to extract per-resource-type access control. Each
+resource type is a `## <Human Name>` top-level section (e.g. `## V1 Past Meeting
+Recording`). Derive `object_type` by lowercasing the heading and replacing
+spaces with underscores (`v1_past_meeting_recording`). Within each section,
+find the `Access Control (IndexingConfig)` table and read:
+
+- `access_check_object` — e.g. `v1_past_meeting:{meeting_and_occurrence_id}`
+- `access_check_relation` — e.g. `viewer`
 
 Strip everything after the first `:` from `access_check_object` to get the
 **delegate type** (e.g., `v1_past_meeting:{meeting_and_occurrence_id}` →

--- a/.agents/skills/render-permissions/SKILL.md
+++ b/.agents/skills/render-permissions/SKILL.md
@@ -301,7 +301,7 @@ itself (nothing includes viewer).
 If no relation in the type has `[user:*]` in its define expression, omit the
 Everyone column entirely. The Everyone column is ALWAYS the rightmost.
 
-## Step 2e — Collect team-suffix annotations
+### 2e — Collect team-suffix annotations
 
 Before writing any output, scan the **existing** `PERMISSIONS.md` for
 `#### Permission Inheritance` bullets that contain one or more "… Team"

--- a/.agents/skills/render-permissions/SKILL.md
+++ b/.agents/skills/render-permissions/SKILL.md
@@ -310,14 +310,11 @@ line (e.g. "global LF Staff Team", "global Product Support Team").
 
 For each such bullet, record the **relation name** (the bold or bold-italic
 text at the start of the bullet) and the **full list of "… Team" phrases**
-found in that bullet. Key these by `(<section-heading>, <relation-name>)`,
-where `<section-heading>` is the nearest preceding `###` heading.
-
-When generating a bullet for that same `(<section-heading>, <relation-name>)`
-pair in Step 3/4, append the preserved team phrases to the generated text,
-separated by a comma. If the relation has no model-derived sources at all
-(i.e. the model would normally omit the bullet entirely), still emit the
-bullet with only the team phrases as its content.
+found in that bullet. Key these by `(<section-heading>, <normalized-relation-name>)`,
+where `<section-heading>` is the nearest preceding `###` heading and
+`<normalized-relation-name>` is the relation display name with all Markdown
+emphasis characters (`*`, `_`) stripped and then lowercased (e.g. `***Owner***`
+→ `owner`, `**Writer**` → `writer`).
 
 This ensures hand-curated global team assignments survive regeneration
 without requiring any special markup in the file.
@@ -369,6 +366,14 @@ only (e.g. "inherited from Project Writer", "inherited from parent Project").
 
 When multiple direct cross-type sources exist for one relation, list them on
 a single bullet separated by commas.
+
+**Team-phrase lookup:** For each bullet emitted, look up
+`(<section-heading>, <normalized-relation-name>)` in the map collected in
+Step 2e, where `<normalized-relation-name>` is the relation display name with
+`*` and `_` stripped and lowercased. If a match is found, append the preserved
+"… Team" phrases to the bullet text, separated by a comma. If the relation has
+no model-derived sources at all (i.e. the bullet would otherwise be omitted),
+still emit the bullet with only the team phrases as its content.
 
 ## Step 4 — Write PERMISSIONS.md
 

--- a/.agents/skills/render-permissions/SKILL.md
+++ b/.agents/skills/render-permissions/SKILL.md
@@ -301,6 +301,27 @@ itself (nothing includes viewer).
 If no relation in the type has `[user:*]` in its define expression, omit the
 Everyone column entirely. The Everyone column is ALWAYS the rightmost.
 
+## Step 2e — Collect team-suffix annotations
+
+Before writing any output, scan the **existing** `PERMISSIONS.md` for
+`#### Permission Inheritance` bullets that contain one or more "… Team"
+references — i.e. any phrase matching `\b\w[\w\s]*Team\b` within a bullet
+line (e.g. "global LF Staff Team", "global Product Support Team").
+
+For each such bullet, record the **relation name** (the bold or bold-italic
+text at the start of the bullet) and the **full list of "… Team" phrases**
+found in that bullet. Key these by `(<section-heading>, <relation-name>)`,
+where `<section-heading>` is the nearest preceding `###` heading.
+
+When generating a bullet for that same `(<section-heading>, <relation-name>)`
+pair in Step 3/4, append the preserved team phrases to the generated text,
+separated by a comma. If the relation has no model-derived sources at all
+(i.e. the model would normally omit the bullet entirely), still emit the
+bullet with only the team phrases as its content.
+
+This ensures hand-curated global team assignments survive regeneration
+without requiring any special markup in the file.
+
 ## Step 3 — Build Permission Inheritance sections
 
 For each **visible** type, for each **direct-grant relation** (has `[user]`,
@@ -460,5 +481,6 @@ After writing, re-read `PERMISSIONS.md` and confirm:
 - The H1 `# LFX Self Service Platform Permissions` is present.
 - The `## Object types` heading is used (not `## Objects supporting role assignment` or `## Entities`).
 - The intro block is unchanged (if it existed before).
+- Every "… Team" phrase that appeared in a Permission Inheritance bullet in the previous file is present in the corresponding bullet in the output (same section, same relation).
 
 Report: types rendered, total columns (excluding Everyone), total JTBD rows.

--- a/PERMISSIONS.md
+++ b/PERMISSIONS.md
@@ -66,6 +66,18 @@ role assignment.
 
 ---
 
+### Committee Invite
+
+| | *Viewer* | Invitee |
+|---|---|---|
+| View a committee invite | ✅ | ✅ |
+
+#### Permission Inheritance
+
+- ***Viewer***: inherited from Committee Auditor
+
+---
+
 ### Groups.io Service
 
 | | Writer | Auditor | *Everyone* |
@@ -190,7 +202,7 @@ role assignment.
 | View org details, settings & committee seats | ✅ | ✅ | ✅ |
 | View org workspaces & workspace projects | ✅ | ✅ | ✅ |
 | Update org details & access settings | ✅ | ✅ | |
-| Manage org workspace membership & projects | ✅ | ✅ | |
+| Manage membership committee seat assignments | ✅ | ✅ | |
 
 #### Permission Inheritance
 

--- a/PERMISSIONS.md
+++ b/PERMISSIONS.md
@@ -24,28 +24,24 @@ role assignment.
 
 ### Project
 
-| | Writer | Auditor | Meeting Coordinator | Executive Director | *Everyone* |
-|---|---|---|---|---|---|
-| View a project | ✅ | ✅ | ✅ | ✅ | 🟡 |
-| View project meeting count | ✅ | ✅ | ✅ | ✅ | 🟡 |
-| View project settings | ✅ | ✅ | | ✅ | |
-| Update project settings | ✅ | | | | |
-| Create & update a project | ✅ | | | | |
-| View project membership tiers | ✅ | ✅ | | ✅ | |
-| View project memberships & member companies | ✅ | ✅ | | ✅ | |
-| View project membership key contacts | ✅ | ✅ | | ✅ | |
-| Manage project membership key contacts | ✅ | | | | |
-| Search B2B organizations | ✅ | ✅ | | ✅ | |
-| View B2B organization memberships | ✅ | ✅ | | ✅ | |
-| Create a vote | ✅ | | | | |
-| Create project committees & mailing lists | ✅ | | | | |
-| Create project meetings | ✅ | | ✅ | | |
-| Create past meetings | ✅ | | ✅ | | |
+| | *Owner* | Writer | Auditor | Meeting Coordinator | Executive Director | *Everyone* |
+|---|---|---|---|---|---|---|
+| View project details & meeting count | ✅ | ✅ | ✅ | ✅ | ✅ | 🟡 |
+| View project links & folders | ✅ | ✅ | ✅ | ✅ | ✅ | 🟡 |
+| View project documents | ✅ | ✅ | ✅ | ✅ | ✅ | 🟡 |
+| View project settings | ✅ | ✅ | ✅ | | ✅ | |
+| Create & update a project | ✅ | ✅ | | | | |
+| Manage project links, folders & documents | ✅ | ✅ | | | | |
+| Delete a project | ✅ | | | | | |
+| Create project committees & Groups.io services | ✅ | ✅ | | | | |
+| Create a vote poll | ✅ | ✅ | | | | |
+| Create meetings & past meetings | ✅ | ✅ | | ✅ | | |
 
 #### Permission Inheritance
 
+- ***Owner***: inherited from parent Project, global Product Support Team, global Formation Team
 - **Writer**: inherited from parent Project
-- **Auditor**: inherited from parent Project
+- **Auditor**: inherited from parent Project, global LF Staff Team, global LF Contractor Team
 
 ---
 
@@ -53,19 +49,15 @@ role assignment.
 
 | | Writer | Auditor | Member | *Everyone* |
 |---|---|---|---|---|
-| View committee details | ✅ | ✅ | ✅ | 🟡 |
+| View committee details & weekly brief | ✅ | ✅ | ✅ | 🟡 |
+| View committee members, invites & applications | ✅ | ✅ | ✅ | 🟡 |
+| View committee links, folders & documents | ✅ | ✅ | ✅ | 🟡 |
 | View committee settings | ✅ | ✅ | | |
-| Update committee settings | ✅ | | | |
-| View committee members | ✅ | ✅ | ✅ | 🟡 |
-| Manage committee members, invites & applications | ✅ | | | |
-| View committee invites | ✅ | ✅ | ✅ | 🟡 |
-| View committee applications | ✅ | ✅ | ✅ | 🟡 |
-| View committee links | ✅ | ✅ | ✅ | 🟡 |
-| View committee link folders | ✅ | ✅ | ✅ | 🟡 |
-| Manage committee links, folders & documents | ✅ | | | |
-| Download committee documents | ✅ | ✅ | ✅ | 🟡 |
-| Schedule a survey for a committee | ✅ | | | |
 | Update & delete a committee | ✅ | | | |
+| Manage committee members, invites & applications | ✅ | | | |
+| Manage committee links, folders & documents | ✅ | | | |
+| Generate & edit the committee weekly brief | ✅ | | | |
+| Create a committee survey | ✅ | | | |
 
 #### Permission Inheritance
 
@@ -81,7 +73,7 @@ role assignment.
 | View a Groups.io service | ✅ | ✅ | 🟡 |
 | View Groups.io service settings | ✅ | ✅ | |
 | Update & delete a Groups.io service | ✅ | | |
-| Create project mailing lists | ✅ | | |
+| Create a Groups.io mailing list | ✅ | | |
 
 #### Permission Inheritance
 
@@ -94,12 +86,11 @@ role assignment.
 
 | | Writer | Auditor | Subscriber | *Everyone* |
 |---|---|---|---|---|
-| View a mailing list | ✅ | ✅ | ✅ | 🟡 |
-| View mailing list settings | ✅ | ✅ | | |
-| View & download mailing list artifacts | ✅ | ✅ | ✅ | 🟡 |
-| View mailing list members | ✅ | ✅ | ✅ | 🟡 |
-| Manage mailing list members | ✅ | | | |
-| Update & delete a mailing list | ✅ | | | |
+| View a Groups.io mailing list & members | ✅ | ✅ | ✅ | 🟡 |
+| View & download Groups.io artifacts | ✅ | ✅ | ✅ | 🟡 |
+| View Groups.io mailing list settings | ✅ | ✅ | | |
+| Manage Groups.io mailing list members | ✅ | | | |
+| Update & delete a Groups.io mailing list | ✅ | | | |
 
 #### Permission Inheritance
 
@@ -112,16 +103,13 @@ role assignment.
 
 | | *Organizer* | *Auditor* | Host | Participant | *Everyone* |
 |---|---|---|---|---|---|
-| View a meeting | ✅ | ✅ | ✅ | ✅ | 🟡 |
+| View a meeting & join link | ✅ | ✅ | ✅ | ✅ | 🟡 |
+| Submit a meeting RSVP & download attachments | ✅ | ✅ | ✅ | ✅ | 🟡 |
+| View meeting registrants & RSVPs | ✅ | ✅ | ✅ | ✅ | 🟡 |
 | View a meeting registrant | ✅ | ✅ | | | |
-| Submit a meeting response | ✅ | ✅ | ✅ | ✅ | 🟡 |
-| Get meeting join link & ICS file | ✅ | ✅ | ✅ | ✅ | 🟡 |
-| View meeting registrants | ✅ | ✅ | ✅ | ✅ | 🟡 |
-| View meeting RSVPs | ✅ | ✅ | ✅ | ✅ | 🟡 |
-| View meeting attachments | ✅ | ✅ | ✅ | ✅ | 🟡 |
+| Manage meeting registrants & invitations | ✅ | | | | |
 | Manage meeting attachments | ✅ | | | | |
-| Manage meeting registrants & occurrences | ✅ | | | | |
-| Update & delete a meeting | ✅ | | | | |
+| Update & delete meetings & occurrences | ✅ | | | | |
 
 #### Permission Inheritance
 
@@ -134,15 +122,13 @@ role assignment.
 
 | | *Organizer* | *Auditor* | Host | Invitee | Attendee | *Everyone* |
 |---|---|---|---|---|---|---|
-| View a past meeting | ✅ | ✅ | ✅ | ✅ | ✅ | 🟡 |
+| View a past meeting & attachments | ✅ | ✅ | ✅ | ✅ | ✅ | 🟡 |
 | View past meeting participants | ✅ | ✅ | ✅ | ✅ | ✅ | 🟡 |
-| View past meeting attachments | ✅ | ✅ | ✅ | ✅ | ✅ | 🟡 |
 | View past meeting recordings | ✅ | ✅ | 🟡 | 🟡 | 🟡 | 🟡 |
 | View past meeting transcripts | ✅ | ✅ | 🟡 | 🟡 | 🟡 | 🟡 |
-| View a past meeting summary | ✅ | ✅ | 🟡 | 🟡 | 🟡 | 🟡 |
-| Update a past meeting summary | ✅ | | | | | |
+| View past meeting AI summaries | ✅ | ✅ | 🟡 | 🟡 | 🟡 | 🟡 |
 | Manage past meeting participants & attachments | ✅ | | | | | |
-| Update & delete a past meeting | ✅ | | | | | |
+| Update & delete past meetings & summaries | ✅ | | | | | |
 
 #### Permission Inheritance
 
@@ -155,12 +141,11 @@ role assignment.
 
 | | *Writer* | *Auditor* | Participant | *Everyone* |
 |---|---|---|---|---|
-| View a vote & its status | ✅ | ✅ | ✅ | 🟡 |
-| View vote responses | ✅ | ✅ | ✅ | 🟡 |
-| View aggregated voting results | ✅ | ✅ | 🟡 | 🟡 |
+| View vote polls & vote responses | ✅ | ✅ | ✅ | 🟡 |
+| View vote results | ✅ | ✅ | 🟡 | 🟡 |
 | Cast a vote response | | | ✅ | |
-| Extend, enable & resend a vote | ✅ | | | |
-| Update & delete a vote | ✅ | | | |
+| Extend a vote & resend notifications | ✅ | | | |
+| Update, enable & delete a vote | ✅ | | | |
 
 #### Permission Inheritance
 
@@ -174,7 +159,7 @@ role assignment.
 | | *Auditor* | Voter |
 |---|---|---|
 | View a vote response | ✅ | ✅ |
-| Update your vote response | | ✅ |
+| Submit & update a vote response | | ✅ |
 
 #### Permission Inheritance
 
@@ -186,13 +171,41 @@ role assignment.
 
 | | *Writer* | *Auditor* | Participant | *Everyone* |
 |---|---|---|---|---|
-| View a survey | ✅ | ✅ | ✅ | 🟡 |
-| View survey responses | ✅ | ✅ | ✅ | 🟡 |
-| Preview survey send recipients | ✅ | ✅ | | |
-| Manage survey recipients & responses | ✅ | | | |
+| View survey details & responses | ✅ | ✅ | ✅ | 🟡 |
+| Preview survey resend impact | ✅ | ✅ | | |
+| Resend survey emails & manage recipients | ✅ | | | |
 | Update & delete a survey | ✅ | | | |
 
 #### Permission Inheritance
 
 - ***Writer***: inherited from Project Writer, Committee Writer
 - ***Auditor***: inherited from Project Auditor, Committee Auditor
+
+---
+
+### B2B Organization
+
+| | Owner | Writer | Auditor |
+|---|---|---|---|
+| View org details, settings & committee seats | ✅ | ✅ | ✅ |
+| View org workspaces & workspace projects | ✅ | ✅ | ✅ |
+| Update org details & access settings | ✅ | ✅ | |
+| Manage org workspace membership & projects | ✅ | ✅ | |
+
+#### Permission Inheritance
+
+- **Auditor**: inherited from parent B2B Organization, child B2B Organization, Project Membership Key Contact
+
+---
+
+### Project Membership
+
+| | *Writer* | *Auditor* | Key Contact |
+|---|---|---|---|
+| View project membership & key contacts | | ✅ | |
+| Create, update & delete key contacts | ✅ | | |
+
+#### Permission Inheritance
+
+- ***Writer***: inherited from B2B Organization Writer
+- ***Auditor***: inherited from B2B Organization Auditor, Project Auditor

--- a/PERMISSIONS.md
+++ b/PERMISSIONS.md
@@ -214,7 +214,7 @@ role assignment.
 
 | | *Writer* | *Auditor* | Key Contact |
 |---|---|---|---|
-| View project membership & key contacts | | ✅ | |
+| View project membership & key contacts | ✅ | ✅ | |
 | Create, update & delete key contacts | ✅ | | |
 
 #### Permission Inheritance

--- a/charts/lfx-platform/templates/openfga/model.yaml
+++ b/charts/lfx-platform/templates/openfga/model.yaml
@@ -39,9 +39,10 @@ spec:
         # @fgadoc:hide
         type team
           relations
-            # @fgadoc:jtbd Manage survey email exclusions
-            # @fgadoc:jtbd Validate survey email templates
-            # @fgadoc:jtbd View survey email templates
+            # @fgadoc:jtbd Create a B2B organization
+            # @fgadoc:jtbd Manage survey exclusions & validate email templates
+            # @fgadoc:jtbd Trigger a data reindex
+            # @fgadoc:jtbd View & manage survey templates
             define member: [user]
 
         type project
@@ -54,29 +55,23 @@ spec:
             # @fgadoc:jtbd Delete a project
             define owner: [team#member] or owner from parent
             # @fgadoc:jtbd Create & update a project
-            # @fgadoc:jtbd Update project settings
-            # @fgadoc:jtbd Create project committees & mailing lists
-            # @fgadoc:jtbd Manage project membership key contacts
-            # @fgadoc:jtbd Create a vote
+            # @fgadoc:jtbd Manage project links, folders & documents
+            # @fgadoc:jtbd Create project committees & Groups.io services
+            # @fgadoc:jtbd Create a vote poll
             define writer: [user] or owner or writer from parent
             # @fgadoc:jtbd View project settings
-            # @fgadoc:jtbd View project membership tiers
-            # @fgadoc:jtbd View project memberships & member companies
-            # @fgadoc:jtbd View project membership key contacts
-            # @fgadoc:jtbd Search B2B organizations
-            # @fgadoc:jtbd View B2B organization memberships
             define auditor: [user, team#member] or executive_director or writer or auditor from parent
             # The meeting_coordinator relation identifies a user who can manage any meeting
             # for a given project.
             define meeting_coordinator: [user]
-            # @fgadoc:jtbd Create project meetings
-            # @fgadoc:jtbd Create past meetings
+            # @fgadoc:jtbd Create meetings & past meetings
             define meetings_creator: writer or meeting_coordinator
             # executive_director identifies a user with the executive director role for a project,
             # as assigned by the project-service. executive_directors are auditors of the project.
             define executive_director: [user]
-            # @fgadoc:jtbd View a project
-            # @fgadoc:jtbd View project meeting count
+            # @fgadoc:jtbd View project details & meeting count
+            # @fgadoc:jtbd View project links & folders
+            # @fgadoc:jtbd View project documents
             define viewer: [user:*] or auditor or meeting_coordinator
 
         type committee
@@ -84,20 +79,16 @@ spec:
             define member: [user]
             define project: [project]
             # @fgadoc:jtbd Update & delete a committee
-            # @fgadoc:jtbd Update committee settings
             # @fgadoc:jtbd Manage committee members, invites & applications
             # @fgadoc:jtbd Manage committee links, folders & documents
-            # @fgadoc:jtbd Schedule a survey for a committee
+            # @fgadoc:jtbd Generate & edit the committee weekly brief
+            # @fgadoc:jtbd Create a committee survey
             define writer: [user] or writer from project
             # @fgadoc:jtbd View committee settings
             define auditor: [user, team#member] or writer or auditor from project or meeting_coordinator from project
-            # @fgadoc:jtbd View committee details
-            # @fgadoc:jtbd Download committee documents
-            # @fgadoc:jtbd View committee members
-            # @fgadoc:jtbd View committee invites
-            # @fgadoc:jtbd View committee applications
-            # @fgadoc:jtbd View committee links
-            # @fgadoc:jtbd View committee link folders
+            # @fgadoc:jtbd View committee details & weekly brief
+            # @fgadoc:jtbd View committee members, invites & applications
+            # @fgadoc:jtbd View committee links, folders & documents
             define viewer: [user:*] or member or auditor
             # set this relation to "self" to enable member access to the roster
             define committee_for_member_roster_access: [committee]
@@ -111,7 +102,7 @@ spec:
           relations
             define project: [project]
             # @fgadoc:jtbd Update & delete a Groups.io service
-            # @fgadoc:jtbd Create project mailing lists
+            # @fgadoc:jtbd Create a Groups.io mailing list
             define writer: [user] or writer from project
             # @fgadoc:jtbd View Groups.io service settings
             define auditor: [user] or auditor from project or writer
@@ -124,14 +115,13 @@ spec:
             define groupsio_service: [groupsio_service]  # Parent relationship
             define project: project from groupsio_service # Inherit project permissions
             define committee: [committee] # Inherit committee permissions
-            # @fgadoc:jtbd Update & delete a mailing list
-            # @fgadoc:jtbd Manage mailing list members
+            # @fgadoc:jtbd Update & delete a Groups.io mailing list
+            # @fgadoc:jtbd Manage Groups.io mailing list members
             define writer: [user] or writer from groupsio_service or writer from committee
-            # @fgadoc:jtbd View mailing list settings
+            # @fgadoc:jtbd View Groups.io mailing list settings
             define auditor: [user] or auditor from groupsio_service or auditor from committee
-            # @fgadoc:jtbd View a mailing list
-            # @fgadoc:jtbd View & download mailing list artifacts
-            # @fgadoc:jtbd View mailing list members
+            # @fgadoc:jtbd View a Groups.io mailing list & members
+            # @fgadoc:jtbd View & download Groups.io artifacts
             define viewer: [user:*] or writer or auditor or member
             # @fgadoc:alias Subscriber
             define member: [user]
@@ -231,18 +221,15 @@ spec:
             # @fgadoc:jtbd View a meeting registrant
             define auditor: organizer or auditor from project
             # No explicit [user] relation for organizer in v1.
-            # @fgadoc:jtbd Update & delete a meeting
-            # @fgadoc:jtbd Manage meeting registrants & occurrences
+            # @fgadoc:jtbd Update & delete meetings & occurrences
+            # @fgadoc:jtbd Manage meeting registrants & invitations
             # @fgadoc:jtbd Manage meeting attachments
             define organizer: meeting_coordinator from project or writer from committee or writer from project
             define host: [user] or organizer
             define participant: [user] or host
-            # @fgadoc:jtbd View a meeting
-            # @fgadoc:jtbd Submit a meeting response
-            # @fgadoc:jtbd Get meeting join link & ICS file
-            # @fgadoc:jtbd View meeting registrants
-            # @fgadoc:jtbd View meeting RSVPs
-            # @fgadoc:jtbd View meeting attachments
+            # @fgadoc:jtbd View a meeting & join link
+            # @fgadoc:jtbd Submit a meeting RSVP & download attachments
+            # @fgadoc:jtbd View meeting registrants & RSVPs
             define viewer: [user:*] or participant or organizer or auditor
 
         # *All relations are as described in `past_meeting`, unless otherwise noted.*
@@ -254,16 +241,14 @@ spec:
             define meeting: [v1_meeting]
             define auditor: organizer or auditor from project or auditor from meeting
             # No explicit [user] relation for organizer in v1.
-            # @fgadoc:jtbd Update & delete a past meeting
+            # @fgadoc:jtbd Update & delete past meetings & summaries
             # @fgadoc:jtbd Manage past meeting participants & attachments
-            # @fgadoc:jtbd Update a past meeting summary
             define organizer: meeting_coordinator from project or writer from project or organizer from meeting
             define host: [user] or organizer
             define invitee: [user]
             define attendee: [user]
-            # @fgadoc:jtbd View a past meeting
+            # @fgadoc:jtbd View a past meeting & attachments
             # @fgadoc:jtbd View past meeting participants
-            # @fgadoc:jtbd View past meeting attachments
             define viewer: [user:*] or attendee or invitee or host or organizer or auditor
             # Per-artifact conditional access — recording
             # "participant" access level means invitee+attendee (both can view).
@@ -288,27 +273,26 @@ spec:
             define past_meeting_for_participant_summary_view: [v1_past_meeting]
             define past_meeting_for_attendee_summary_view: [v1_past_meeting]
             define past_meeting_for_host_summary_view: [v1_past_meeting]
-            # @fgadoc:jtbd View a past meeting summary
+            # @fgadoc:jtbd View past meeting AI summaries
             define ai_summary_viewer: [user:*] or organizer or auditor or invitee from past_meeting_for_participant_summary_view or attendee from past_meeting_for_attendee_summary_view or host from past_meeting_for_host_summary_view
 
         type vote
           relations
             define committee: [committee]
             define project: [project]
-            # @fgadoc:jtbd Update & delete a vote
-            # @fgadoc:jtbd Extend, enable & resend a vote
+            # @fgadoc:jtbd Update, enable & delete a vote
+            # @fgadoc:jtbd Extend a vote & resend notifications
             define writer: writer from project or writer from committee
             # auditor has access to participants, viewer does not
             define auditor: writer or auditor from project or auditor from committee
             # @fgadoc:jtbd Cast a vote response
             define participant: [user]
-            # @fgadoc:jtbd View a vote & its status
-            # @fgadoc:jtbd View vote responses
+            # @fgadoc:jtbd View vote polls & vote responses
             define viewer: [user:*] or auditor or participant
             define vote_for_participant_result_access: [vote] # set this relation to "self" to enable access
             # results_viewer is not for viewing the actual related vote_response objects,
             # but rather for an aggregate summary which can be made optionally public
-            # @fgadoc:jtbd View aggregated voting results
+            # @fgadoc:jtbd View vote results
             define results_viewer: [user:*] or auditor or participant from vote_for_participant_result_access
 
         type vote_response
@@ -316,7 +300,7 @@ spec:
             define vote: [vote]
             # owner is the user who cast this response
             # @fgadoc:alias Voter
-            # @fgadoc:jtbd Update your vote response
+            # @fgadoc:jtbd Submit & update a vote response
             define owner: [user]
             # we don't need to create a "writer" relation that is defined as just "owner":
             # we just use the "owner" relation in our access checks!
@@ -328,14 +312,13 @@ spec:
             define committee: [committee]
             define project: [project]
             # @fgadoc:jtbd Update & delete a survey
-            # @fgadoc:jtbd Manage survey recipients & responses
+            # @fgadoc:jtbd Resend survey emails & manage recipients
             define writer: writer from project or writer from committee
             # auditor has access to participants, viewer does not
-            # @fgadoc:jtbd Preview survey send recipients
+            # @fgadoc:jtbd Preview survey resend impact
             define auditor: writer or auditor from project or auditor from committee
             define participant: [user]
-            # @fgadoc:jtbd View a survey
-            # @fgadoc:jtbd View survey responses
+            # @fgadoc:jtbd View survey details & responses
             define viewer: [user:*] or auditor or participant
             define survey_for_participant_result_access: [survey] # set this relation to "self" to enable access
             # results_viewer is not for viewing the actual related survey_response objects,
@@ -364,9 +347,13 @@ spec:
             # @fgadoc:hide
             define global_org_admin: [team#member]
             define owner: [user]
+            # @fgadoc:jtbd Update org details & access settings
+            # @fgadoc:jtbd Manage org workspace membership & projects
             define writer: [user] or owner or global_org_admin
             # auditor cascades transitively up and down the hierarchy via parent/child.
             # writer does NOT cascade — edit scope stays on the directly-assigned org only.
+            # @fgadoc:jtbd View org details, settings & committee seats
+            # @fgadoc:jtbd View org workspaces & workspace projects
             define auditor: [user, team#member] or writer or auditor from parent or auditor from child or key_contact from membership
             # parent is included to model company subsidiaries (a b2b_org may have a
             # parent b2b_org in Salesforce).
@@ -389,7 +376,9 @@ spec:
           relations
             define b2b_org: [b2b_org]
             define project: [project]
+            # @fgadoc:jtbd Create, update & delete key contacts
             define writer: writer from b2b_org
+            # @fgadoc:jtbd View project membership & key contacts
             define auditor: auditor from b2b_org or auditor from project
             define key_contact: [user]
 {{- end }}

--- a/charts/lfx-platform/templates/openfga/model.yaml
+++ b/charts/lfx-platform/templates/openfga/model.yaml
@@ -98,6 +98,7 @@ spec:
             define committee: [committee]
             # The invitee relation identifies the user who was invited to the committee.
             define invitee: [user]
+            # @fgadoc:jtbd View a committee invite
             define viewer: invitee or auditor from committee
 
         # @fgadoc:alias Groups.io Service
@@ -351,7 +352,7 @@ spec:
             define global_org_admin: [team#member]
             define owner: [user]
             # @fgadoc:jtbd Update org details & access settings
-            # @fgadoc:jtbd Manage org workspace membership & projects
+            # @fgadoc:jtbd Manage membership committee seat assignments
             define writer: [user] or owner or global_org_admin
             # auditor cascades transitively up and down the hierarchy via parent/child.
             # writer does NOT cascade — edit scope stays on the directly-assigned org only.

--- a/charts/lfx-platform/templates/openfga/model.yaml
+++ b/charts/lfx-platform/templates/openfga/model.yaml
@@ -28,7 +28,7 @@ spec:
     - version:
         major: 14
         minor: 0
-        patch: 0
+        patch: 1
       authorizationModel: |
         model
           schema 1.1
@@ -383,6 +383,6 @@ spec:
             # @fgadoc:jtbd Create, update & delete key contacts
             define writer: writer from b2b_org
             # @fgadoc:jtbd View project membership & key contacts
-            define auditor: auditor from b2b_org or auditor from project
+            define auditor: writer or auditor from b2b_org or auditor from project
             define key_contact: [user]
 {{- end }}

--- a/charts/lfx-platform/templates/openfga/model.yaml
+++ b/charts/lfx-platform/templates/openfga/model.yaml
@@ -48,10 +48,6 @@ spec:
         type project
           relations
             define parent: [project]
-            # Hiding `owner` relation AND "delete a project" JTBD because we
-            # are not yet documenting "global group/team permissions" in the
-            # output.
-            # @fgadoc:hide
             # @fgadoc:jtbd Delete a project
             define owner: [team#member] or owner from parent
             # @fgadoc:jtbd Create & update a project


### PR DESCRIPTION
## Summary

Documentation and correctness update to the OpenFGA authorization model, permissions reference, and agent skills.

### Commits

**1. `cc9a8b8` — Refresh `@fgadoc:jtbd` annotations from live RuleSets**

Ran the `populate-jtbds` skill against the dev cluster:
- 27 object#relation groups updated, 8 already current
- 65 total `@fgadoc:jtbd` lines (net reduction from consolidation)
- Newly populated: `b2b_org#writer`, `b2b_org#auditor`, `project_membership#writer`, `project_membership#auditor`
- Consolidated verbose per-route lists into compound user-action statements
- Fixed all "GroupsIO" → "Groups.io" references

No authorization model logic changed; documentation only, no version bump required.

**2. `f1fe960` — Fix indexer contract source in `populate-jtbds` skill**

The skill was pointing at the wrong upstream doc for discovering per-resource indexer contracts. Updated to use `lfx-v2-query-service/docs/indexed-data-types.md` to discover owning service repos, then fetch `docs/indexer-contract.md` from each directly.

**3. `db10b45` — Re-render `PERMISSIONS.md` with updated model and skill**

- Unhide `owner` relation on `project` type (indirect-only, team-member grant) — now appears as *Owner* column
- Update `render-permissions` skill with Step 2e team-suffix annotation logic to preserve hand-curated global team assignments across regenerations
- Regenerate `PERMISSIONS.md`: refreshed JTBDs reflected, *Owner* column added to Project table, new **B2B Organization** and **Project Membership** sections added

**4. `44bec15` — Fix Step 2e heading level in `render-permissions` skill**

Step 2e was using `##` (top-level) instead of `###` like the other 2a–2d subsections, breaking the heading hierarchy.

**5. `9df3bf3` — Normalize relation-name keys in Step 2e team lookup**

Strip Markdown emphasis (`*` and `_`) and lowercase both the scan key (Step 2e) and the generation lookup (Step 3) so bold vs bold-italic variants always resolve to the same map entry.

**6. `804ba8b` — Refresh `@fgadoc:jtbd` annotations (second pass, post-LFXV2-2402 merge)**

Follow-up annotation refresh after the `committee_invite` type landed in main via #148:
- Add `@fgadoc:jtbd "View a committee invite"` to `committee_invite#viewer`
- Replace stale `b2b_org#writer` JTBD copy with "Manage membership committee seat assignments" and "Update org details & access settings"
- Re-render `PERMISSIONS.md`: add Committee Invite section, update B2B Org rows

**7. `fe29f3a` — Fix `project_membership#auditor` model relation (version bump to 14.0.1)**

> ⚠️ This is the only commit that changes actual authorization model logic.

`project_membership#auditor` was defined as `auditor from b2b_org or auditor from project`, relying on the fact that `b2b_org#auditor` transitively includes `b2b_org#writer`. However, the `render-permissions` skill only performs same-type upward reachability — it does not traverse cross-entity inclusion chains — so the generated `PERMISSIONS.md` incorrectly showed the *Writer* column without read access on Project Membership rows.

Fix: add an explicit same-type `or writer` to the `auditor` define:

```
define auditor: writer or auditor from b2b_org or auditor from project
```

This makes writers always also auditors on the same `project_membership` object, which is the correct semantic (org writers who can manage membership records should obviously also be able to read them). Model bumped to **14.0.1** (patch: modification of `define`).

---

🤖 Generated with [GitHub Copilot](https://github.com/features/copilot) (via OpenCode)