### PR TITLE
feat(openfga): remove redundant campaign_viewer and marketing_dashboard_viewer relations [LFXV2-2231]

### DIFF
--- a/charts/lfx-platform/files/model.fga
+++ b/charts/lfx-platform/files/model.fga
@@ -34,6 +34,12 @@ type project
     # as assigned by the project-service. executive_directors are auditors of the project.
     define executive_director: [user]
     define marketing_ops: [team#member] or marketing_ops from parent
+    # marketing_auditor identifies a user with read access to marketing dashboards
+    # and campaigns for a project. Unlike campaign_manager, marketing_auditor
+    # cascades from parent projects — granting it at ROOT flows down to all
+    # sub-projects. The manager role does not cascade from parent; management
+    # rights are explicitly scoped to the project on which they are granted.
+    define marketing_auditor: executive_director or marketing_ops or marketing_auditor from parent
     define campaign_manager: executive_director or marketing_ops
     # @fgadoc:jtbd View project details & meeting count
     # @fgadoc:jtbd View project links & folders

--- a/charts/lfx-platform/files/model.fga
+++ b/charts/lfx-platform/files/model.fga
@@ -39,7 +39,7 @@ type project
     # cascades from parent projects — granting it at ROOT flows down to all
     # sub-projects. The manager role does not cascade from parent; management
     # rights are explicitly scoped to the project on which they are granted.
-    define marketing_auditor: executive_director or marketing_ops or marketing_auditor from parent
+    define marketing_auditor: [team#member] or executive_director or marketing_ops or marketing_auditor from parent
     define campaign_manager: executive_director or marketing_ops
     # @fgadoc:jtbd View project details & meeting count
     # @fgadoc:jtbd View project links & folders

--- a/charts/lfx-platform/files/model.fga
+++ b/charts/lfx-platform/files/model.fga
@@ -34,8 +34,6 @@ type project
     # as assigned by the project-service. executive_directors are auditors of the project.
     define executive_director: [user]
     define marketing_ops: [team#member] or marketing_ops from parent
-    define marketing_dashboard_viewer: executive_director or marketing_ops
-    define campaign_viewer: executive_director or marketing_ops
     define campaign_manager: executive_director or marketing_ops
     # @fgadoc:jtbd View project details & meeting count
     # @fgadoc:jtbd View project links & folders

--- a/charts/lfx-platform/templates/openfga/model.yaml
+++ b/charts/lfx-platform/templates/openfga/model.yaml
@@ -27,7 +27,7 @@ spec:
 */}}
     - version:
         major: 14
-        minor: 1
+        minor: 2
         patch: 0
       authorizationModel: |
 {{ .Files.Get "files/model.fga" | indent 8 }}


### PR DESCRIPTION
## Summary

Refines the marketing relations on the `project` type in the shared OpenFGA authorization model based on product alignment (Slack, 2026-06-26).

### What changed

**Removed** two redundant, identically-defined viewer relations:
- `campaign_viewer: executive_director or marketing_ops`
- `marketing_dashboard_viewer: executive_director or marketing_ops`

**Added** `marketing_auditor` — a properly-structured read role:
- Accepts `[team#member]` as a direct assignee, so a marketing auditor team can be written onto a project tuple explicitly (mirroring `marketing_ops`)
- Derives membership transitively from `executive_director` and `marketing_ops`
- **Cascades from parent** via `marketing_auditor from parent` — granting it at ROOT flows down to all sub-projects in the hierarchy

**Kept** `campaign_manager` unchanged — management rights are intentionally scoped to the project on which they are granted and do not cascade from parent.

### Resulting model (marketing relations only)

```
define marketing_ops: [team#member] or marketing_ops from parent
define marketing_auditor: [team#member] or executive_director or marketing_ops or marketing_auditor from parent
define campaign_manager: executive_director or marketing_ops
```

**Model version bumped:** 14.1.0 → 14.2.0 (minor — relation additions/deletions).

## Changes

```
 charts/lfx-platform/files/model.fga              | 8 ++++++--
 charts/lfx-platform/templates/openfga/model.yaml | 2 +-
 2 files changed, 7 insertions(+), 3 deletions(-)
```

Jira: LFXV2-2231