### PR TITLE
chore: bump MegaLinter to v9.6.0

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -57,9 +57,15 @@
     "webauthn",
     "websecure",
     "stakater",
+    "artipacked",
+    "BETTERLEAKS",
     "fgadoc",
     "jtbd",
-    "jtbds"
+    "jtbds",
+    "lockfiles",
+    "TERRASCAN",
+    "zizmor",
+    "ZIZMOR"
   ],
   "flagWords": [
     "abort",

--- a/.github/workflows/fga-model-check.yml
+++ b/.github/workflows/fga-model-check.yml
@@ -8,7 +8,7 @@ jobs:
   fga-model-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/fga-model-check.yml
+++ b/.github/workflows/fga-model-check.yml
@@ -11,6 +11,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Check version bump when model changes
         env:
           BASE_REF: ${{ github.base_ref }}

--- a/.github/workflows/license-header-check.yml
+++ b/.github/workflows/license-header-check.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   license-header-check:
     name: License Header Check
-    uses: linuxfoundation/lfx-public-workflows/.github/workflows/license-header-check.yml@main
+    uses: linuxfoundation/lfx-public-workflows/.github/workflows/license-header-check.yml@8313b4b18b95d750f99a78d5ea160d851afbc40b  # main
     with:
       copyright_line: "Copyright The Linux Foundation and each contributor to LFX."
       include_files: "*.tpl"

--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       # Git Checkout
       - name: Checkout Code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -54,3 +54,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # Allow GITHUB_TOKEN for working around rate limits (aquasecurity/trivy#7668).
           REPOSITORY_TRIVY_UNSECURED_ENV_VARIABLES: GITHUB_TOKEN
+          # Allow GITHUB_TOKEN so zizmor can resolve action tags for the
+          # artipacked audit (online mode).
+          ACTION_ZIZMOR_UNSECURED_ENV_VARIABLES: GITHUB_TOKEN

--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -28,6 +28,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       # Installs packaged subcharts under charts/*/charts/*.tgz. Also
       # fails if the Chart.lock digest is wrong.

--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -47,7 +47,7 @@ jobs:
       - name: MegaLinter
         id: ml
         # Use the Documentation flavor.
-        uses: oxsecurity/megalinter/flavors/documentation@5a91fb06c83d0e69fbd23756d47438aa723b4a5a  # 8.7.0
+        uses: oxsecurity/megalinter/flavors/documentation@ef3e84b8b836d76db562d0f3ed7da61e8fd538bc  # v9.6.0
         env:
           # All available variables are described in documentation
           # https://megalinter.io/configuration/

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,7 +28,7 @@ jobs:
       image_name: ${{ steps.publish-ghcr.outputs.image_name }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           persist-credentials: false
 
@@ -39,7 +39,7 @@ jobs:
         run: |
           set -euo pipefail
           CHART_NAME="$(yq '.name' charts/*/Chart.yaml)"
-          CHART_VERSION=$(echo "$REF_NAME" | sed 's/v//g')
+          CHART_VERSION="${REF_NAME#v}"
           {
             echo "chart_name=$CHART_NAME"
             echo "chart_version=$CHART_VERSION"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,13 +29,17 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
+        with:
+          persist-credentials: false
 
       - name: Prepare versions and chart name
         id: prepare
+        env:
+          REF_NAME: ${{ github.ref_name }}
         run: |
           set -euo pipefail
           CHART_NAME="$(yq '.name' charts/*/Chart.yaml)"
-          CHART_VERSION=$(echo ${{ github.ref_name }} | sed 's/v//g')
+          CHART_VERSION=$(echo "$REF_NAME" | sed 's/v//g')
           {
             echo "chart_name=$CHART_NAME"
             echo "chart_version=$CHART_VERSION"
@@ -68,9 +72,11 @@ jobs:
       - name: Sign the Helm chart in GHCR
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          IMAGE_NAME: ${{ steps.publish-ghcr.outputs.image_name }}
+          IMAGE_DIGEST: ${{ steps.publish-ghcr.outputs.digest }}
         run: |
           set -euo pipefail
-          cosign sign --yes '${{ steps.publish-ghcr.outputs.image_name }}@${{ steps.publish-ghcr.outputs.digest }}'
+          cosign sign --yes "${IMAGE_NAME}@${IMAGE_DIGEST}"
 
   create-ghcr-helm-provenance:
     needs:
@@ -79,10 +85,9 @@ jobs:
       actions: read
       id-token: write
       packages: write
-    # Note, this action *cannot* be pinned to a ref: see the project's
-    # explanation at "Referencing SLSA builders and generators" in their
-    # README.
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.1.0
+    # Note, this action *cannot* be pinned to a SHA: see the project's
+    # explanation at "Referencing SLSA builders and generators" in their README.
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.1.0  # zizmor: ignore[unpinned-uses]
     with:
       image: ${{ needs.release-helm-chart.outputs.image_name }}
       digest: ${{ needs.release-helm-chart.outputs.digest }}

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -16,6 +16,12 @@ DISABLE_LINTERS:
   - SPELL_LYCHEE
   # yamllint is sufficient for us.
   - YAML_PRETTIER
+  # No lockfiles, manifests, or SBOMs in this repo for osv-scanner to scan.
+  - REPOSITORY_OSV_SCANNER
+  # Deprecated in v9 (superseded by REPOSITORY_BETTERLEAKS).
+  - REPOSITORY_GITLEAKS
+  # Deprecated in v9 (repo archived).
+  - TERRAFORM_TERRASCAN
 DISABLE_ERRORS_LINTERS:
   # Include grammar checks only as warnings.
   - SPELL_PROSELINT
@@ -25,6 +31,8 @@ DISABLE_ERRORS_LINTERS:
   # TBD! Need to work through these.
   - REPOSITORY_TRIVY
   - REPOSITORY_CHECKOV
+  # zizmor artipacked audit requires GitHub API access not available in PR context.
+  - ACTION_ZIZMOR
 SPELL_CSPELL_ANALYZE_FILE_NAMES: false
 # Make sure Vale is setup to run with the styles it needs.
 SPELL_VALE_PRE_COMMANDS:

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -31,8 +31,9 @@ DISABLE_ERRORS_LINTERS:
   # TBD! Need to work through these.
   - REPOSITORY_TRIVY
   - REPOSITORY_CHECKOV
-  # zizmor artipacked audit requires GitHub API access not available in PR context.
-  - ACTION_ZIZMOR
+# zizmor artipacked audit requires git smart-HTTP access unavailable in PR
+# context; run offline to skip remote tag resolution.
+ACTION_ZIZMOR_ARGUMENTS: --offline
 SPELL_CSPELL_ANALYZE_FILE_NAMES: false
 # Make sure Vale is setup to run with the styles it needs.
 SPELL_VALE_PRE_COMMANDS:

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -31,9 +31,6 @@ DISABLE_ERRORS_LINTERS:
   # TBD! Need to work through these.
   - REPOSITORY_TRIVY
   - REPOSITORY_CHECKOV
-# zizmor artipacked audit requires git smart-HTTP access unavailable in PR
-# context; run offline to skip remote tag resolution.
-ACTION_ZIZMOR_ARGUMENTS: --offline
 SPELL_CSPELL_ANALYZE_FILE_NAMES: false
 # Make sure Vale is setup to run with the styles it needs.
 SPELL_VALE_PRE_COMMANDS:

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ To contribute to this repository:
    ```bash
    docker run --rm --platform linux/amd64 \
      -v "$(pwd):/tmp/lint:rw" \
-     oxsecurity/megalinter-documentation:v9.6.0
+     ghcr.io/oxsecurity/megalinter-documentation:v9.6.0
    ```
 6. Submit your pull request
 

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ To contribute to this repository:
    ```bash
    docker run --rm --platform linux/amd64 \
      -v "$(pwd):/tmp/lint:rw" \
-     oxsecurity/megalinter-documentation:v8
+     oxsecurity/megalinter-documentation:v9.6.0
    ```
 6. Submit your pull request
 


### PR DESCRIPTION
## Summary

Bumps MegaLinter from `8.7.0` to `v9.6.0` to address a grype vulnerability scanner issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Issue: LFXV2-1167