### PR TITLE
fix(authelia): add trailing slash to lfx-api client audiences

### DIFF
--- a/charts/lfx-platform/values.yaml
+++ b/charts/lfx-platform/values.yaml
@@ -566,7 +566,7 @@ authelia:
             scopes:
               - none
             audience:
-              - "http://lfx-api.k8s.orb.local"
+              - "http://lfx-api.k8s.orb.local/"
             grant_types:
               - client_credentials
             authorization_policy: one_factor
@@ -582,7 +582,7 @@ authelia:
               - profile
               - offline_access
             audience:
-              - "http://lfx-api.k8s.orb.local"
+              - "http://lfx-api.k8s.orb.local/"
             grant_types:
               - authorization_code
               - refresh_token
@@ -601,7 +601,7 @@ authelia:
               - offline_access
               - access:api
             audience:
-              - "http://lfx-api.k8s.orb.local"
+              - "http://lfx-api.k8s.orb.local/"
             grant_types:
               - authorization_code
               - refresh_token
@@ -620,7 +620,7 @@ authelia:
               - profile
               - api:access
             audience:
-              - "http://lfx-api.k8s.orb.local"
+              - "http://lfx-api.k8s.orb.local/"
             grant_types:
               - implicit
             authorization_policy: one_factor


### PR DESCRIPTION
## Problem

Heimdall's `oidc` introspection authenticator asserts the API gateway audience **with** a trailing slash (matching our production Auth0 `resource_server` naming convention):

```yaml
# charts/lfx-platform/values.yaml (heimdall … authenticators … oidc)
assertions:
  audience:
    - "http://lfx-api.k8s.orb.local/"   # ← trailing slash
```

But the local Authelia clients (`m2m_test`, `token_helper`, `lfx`, `docs`) issue tokens whose `aud` has **no** trailing slash:

```yaml
audience:
  - "http://lfx-api.k8s.orb.local"       # ← no slash (drifted from the assertion)
```

Heimdall does an **exact** match, so a token carrying `aud: http://lfx-api.k8s.orb.local` never satisfies `http://lfx-api.k8s.orb.local/`. The `oidc` authenticator fails, the pipeline falls through to the anonymous authenticator, and **every token that clears introspection is treated as anonymous** — breaking all authenticated (writer-gated) access on the full-local (`k8s.orb.local`) stack.

## Fix

Per review, keep the trailing slash (consistent with prod Auth0 `resource_servers`) and align the **client** audiences up to it, rather than dropping it from the assertion. Adds the trailing slash to the four Authelia client `audience` values.

## Follow-up for full-local devs

Callers must request the same audience. In your local `apps/lfx-one/.env` (lfx-self-serve), add the trailing slash to:

- `PCC_AUTH0_AUDIENCE`
- `M2M_AUTH_AUDIENCE`
- `API_GW_AUDIENCE`

(These live only in each dev's gitignored `.env`; `.env.example` uses placeholders, so no source change there. The base-URL env `LFX_V2_SERVICE` is a separate value and is unchanged.)

## Reproduction

```bash
AT=$(curl -s -u m2m_test:$SECRET -d 'grant_type=client_credentials&scope=none&audience=http://lfx-api.k8s.orb.local/' \
  https://auth.k8s.orb.local/api/oidc/token | jq -r .access_token)
curl -s -o /dev/null -w '%{http_code}\n' -H "Authorization: Bearer $AT" \
  http://lfx-api.k8s.orb.local/projects/<uid>/settings   # → 200 once both sides use the slash
```

Introspection reports `active: true` regardless; the request only resolves to a real principal (not `_anonymous`) once the token audience and the assertion match.