### PR TITLE
[LFXV2-2677] fix(heimdall): emit email_verified claim in create_jwt finalizer

### DIFF
--- a/charts/lfx-platform/values.yaml
+++ b/charts/lfx-platform/values.yaml
@@ -408,7 +408,8 @@ heimdall:
                 | quote
               }}
               {{ if .Outputs.oidc_contextualizer.email -}},
-              "email": {{ quote .Outputs.oidc_contextualizer.email }}
+              "email": {{ quote .Outputs.oidc_contextualizer.email }},
+              "email_verified": {{ .Outputs.oidc_contextualizer.email_verified }}
               {{ end -}}
               {{ if .Values.aud -}},
               "aud": {{ quote .Values.aud }}

--- a/charts/lfx-platform/values.yaml
+++ b/charts/lfx-platform/values.yaml
@@ -409,7 +409,7 @@ heimdall:
               }}
               {{ if .Outputs.oidc_contextualizer.email -}},
               "email": {{ quote .Outputs.oidc_contextualizer.email }},
-              "email_verified": {{ .Outputs.oidc_contextualizer.email_verified }}
+              "email_verified": {{ .Outputs.oidc_contextualizer.email_verified | default false }}
               {{ end -}}
               {{ if .Values.aud -}},
               "aud": {{ quote .Values.aud }}


### PR DESCRIPTION
## Summary

- The `oidc_contextualizer` already receives `email_verified` from Authelia's userinfo endpoint (reflecting Auth0's account verification state), but the `create_jwt` finalizer template was not forwarding it into the signed Heimdall JWT
- Add `email_verified` alongside the existing `email` claim in the finalizer, keeping it inside the same `{{ if .Outputs.oidc_contextualizer.email }}` conditional — so M2M and anonymous tokens are unaffected
- Downstream services can now gate on `email_verified` before using the JWT email for identity resolution

## Ticket

[LFXV2-2677](https://linuxfoundation.atlassian.net/browse/LFXV2-2677)

## Context

Required by `lfx-v2-committee-service#156`, which uses `email_verified` to guard a propagation-race fallback in `resolveCallerEmail`. When a brand-new LFID user accepts a committee invite before Auth0 → auth-service propagation completes, the committee service falls back to the JWT `email` claim — but only when `email_verified` is `true`.

**Deployment order**: this Heimdall change must be deployed **before** the committee service PR for the fallback to become active.

## Test plan

- [ ] Deploy locally and verify that a user JWT contains `email_verified: true` alongside `email` in the Heimdall-signed JWT
- [ ] Verify M2M tokens (no email claim) are unaffected — `email_verified` is absent when `email` is absent
- [ ] Verify anonymous tokens are unaffected

🤖 Generated with [Claude Code](https://claude.ai/code)

[LFXV2-2677]: https://linuxfoundation.atlassian.net/browse/LFXV2-2677?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ