### PR TITLE
[LFXV2-2677] fix(heimdall): fail pipeline on unverified email from oidc_contextualizer

### DIFF
--- a/charts/lfx-platform/values.yaml
+++ b/charts/lfx-platform/values.yaml
@@ -408,8 +408,8 @@ heimdall:
                 | quote
               }}
               {{ if .Outputs.oidc_contextualizer.email -}},
-              "email": {{ quote .Outputs.oidc_contextualizer.email }},
-              "email_verified": {{ .Outputs.oidc_contextualizer.email_verified | default false }}
+              {{- if not .Outputs.oidc_contextualizer.email_verified }}{{ fail "request denied: oidc_contextualizer returned unverified email" }}{{ end }}
+              "email": {{ quote .Outputs.oidc_contextualizer.email }}
               {{ end -}}
               {{ if .Values.aud -}},
               "aud": {{ quote .Values.aud }}


### PR DESCRIPTION
## Summary

- Replaces the forwarded `email_verified` downstream JWT claim with a Heimdall pipeline `fail` when the `oidc_contextualizer` returns an email with `email_verified=false`
- M2M and anonymous tokens are unaffected — the outer `email`-present guard is false for those tokens, so the `fail` branch is never reached
- Removes `email_verified` from the downstream JWT entirely; services no longer need per-service verification checks

## Context

Auth0 does not include `email_verified` in access tokens, and Auth0 Actions already gate issuance so only verified users receive LFX v2 tokens. The only source of an unverified profile is Authelia's `oidc_contextualizer`. Rather than requiring every downstream service to gate on an `email_verified` claim, the guarantee is now enforced at the infrastructure layer in Heimdall.

This is a follow-up to #155, which added `email_verified` as a forwarded claim. That approach was correct as a safety net but placed the verification responsibility on each service. Eric Searcy identified that Heimdall is the right place to enforce this.

The companion commit in `lfx-v2-committee-service` removes `EmailVerified` from `HeimdallClaims` and the `filterEmailByVerification` helper, as those are now redundant.

## Ticket

[LFXV2-2677](https://linuxfoundation.atlassian.net/browse/LFXV2-2677)

🤖 Generated with [Claude Code](https://claude.ai/code)

[LFXV2-2677]: https://linuxfoundation.atlassian.net/browse/LFXV2-2677?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ