### PR TITLE
[LFXV2-2358] Grant auditors the host relation on meeting types

### DIFF
--- a/charts/lfx-platform/files/model.fga
+++ b/charts/lfx-platform/files/model.fga
@@ -162,7 +162,7 @@ type past_meeting
     # That means they can update the past meeting details, update the participants, etc.
     define organizer: [user] or meeting_coordinator from project or writer from project or organizer from meeting
     # The host relation identifies a user who was a host of this past meeting.
-    define host: [user] or organizer
+    define host: [user]
     # The invitee relation identifies a participant who was invited to this past meeting.
     define invitee: [user]
     # The attendee relation identifies a participant who attended this past meeting.
@@ -227,7 +227,7 @@ type v1_past_meeting
     # The host relation identifies a user who was a host of this past meeting.
     # It is used to gate conditional access to recordings, transcripts, and AI summaries
     # via the self-referential flag tuples below.
-    define host: [user] or organizer
+    define host: [user]
     define invitee: [user]
     define attendee: [user]
     # @fgadoc:jtbd View a past meeting & attachments

--- a/charts/lfx-platform/files/model.fga
+++ b/charts/lfx-platform/files/model.fga
@@ -123,7 +123,7 @@ type meeting
     # the user who is hosting the meeting, nor is the host necessarily the one who is
     # organizing the meeting. For example, a host may need to retrieve the Zoom host key
     # but shouldn't be able to update the meeting details.
-    define host: [user] or organizer
+    define host: [user] or auditor
     # The participant relation identifies a user who is a participant in this meeting.
     # This can either mean they are invited to the meeting or they attended the meeting
     # without being invited. In either case, they are a participant of that meeting.
@@ -205,7 +205,7 @@ type v1_meeting
     # @fgadoc:jtbd Manage meeting registrants & invitations
     # @fgadoc:jtbd Manage meeting attachments
     define organizer: meeting_coordinator from project or writer from committee or writer from project
-    define host: [user] or organizer
+    define host: [user] or auditor
     define participant: [user] or host
     # @fgadoc:jtbd View a meeting & join link
     # @fgadoc:jtbd Submit a meeting RSVP & download attachments
@@ -224,6 +224,9 @@ type v1_past_meeting
     # @fgadoc:jtbd Update & delete past meetings & summaries
     # @fgadoc:jtbd Manage past meeting participants & attachments
     define organizer: meeting_coordinator from project or writer from project or organizer from meeting
+    # The host relation identifies a user who was a host of this past meeting.
+    # It is used to gate conditional access to recordings, transcripts, and AI summaries
+    # via the self-referential flag tuples below.
     define host: [user] or organizer
     define invitee: [user]
     define attendee: [user]

--- a/charts/lfx-platform/templates/openfga/model.yaml
+++ b/charts/lfx-platform/templates/openfga/model.yaml
@@ -28,7 +28,7 @@ spec:
     - version:
         major: 14
         minor: 2
-        patch: 0
+        patch: 1
       authorizationModel: |
 {{ .Files.Get "files/model.fga" | indent 8 }}
 {{- end }}


### PR DESCRIPTION
## Summary

- Changes \`host\` relation on \`meeting\` and \`v1_meeting\` from \`[user] or organizer\` to \`[user] or auditor\`, so all auditors (and organizers via transitivity) gain the host relation
- Removes the \`or organizer\` pass-through on \`past_meeting\` and \`v1_past_meeting\` host relations, leaving them as \`[user]\` only — the host relation on past meetings is for explicitly-assigned hosts (used to gate conditional recording/transcript/AI summary access via flag tuples), and organizers already have unconditional access to those artifacts via their own viewer definitions
- Adds a comment to \`v1_past_meeting#host\` clarifying it gates conditional recording/transcript/AI summary access via self-referential flag tuples

## Context

As part of LFXV2-2358, \`host_key\` (Zoom host claim PIN) will be separated into a permissioned \`host_credentials\` sub-object accessible only to users with the \`host\` relation. Jordan confirmed auditors should be able to see the host key; Eric recommended making \`auditor\` the transitive source rather than \`organizer\` (organizer is already included in auditor, so listing it separately would be redundant). Past meeting payloads contain no \`host_key\` field, so no cleanup was needed there.

## Ticket

[LFXV2-2358](https://linuxfoundation.atlassian.net/browse/LFXV2-2358)

## Test plan

- [ ] Verify FGA model validates cleanly when deployed to the local stack
- [ ] Confirm an auditor-only user (not organizer) has the \`host\` relation on a meeting after this model is deployed
- [ ] Confirm \`v1_past_meeting\` host relation is unchanged and still gates recording/transcript/summary access correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[LFXV2-2358]: https://linuxfoundation.atlassian.net/browse/LFXV2-2358?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ