### PR TITLE
[LFXV2-2690] feat(fga): add inviter relation to committee type

### DIFF
--- a/PERMISSIONS.md
+++ b/PERMISSIONS.md
@@ -57,6 +57,7 @@ role assignment.
 | Manage committee members, invites & applications | ✅ | | | |
 | Manage committee links, folders & documents | ✅ | | | |
 | Generate & edit the committee weekly brief | ✅ | | | |
+| Invite a user to join a committee | ✅ | ✅ | ✅ | |
 | Create a committee survey | ✅ | | | |
 
 #### Permission Inheritance

--- a/PERMISSIONS.md
+++ b/PERMISSIONS.md
@@ -57,7 +57,7 @@ role assignment.
 | Manage committee members, invites & applications | ✅ | | | |
 | Manage committee links, folders & documents | ✅ | | | |
 | Generate & edit the committee weekly brief | ✅ | | | |
-| Invite a user to join a committee | ✅ | ✅ | ✅ | |
+| Invite a user to join a committee when join mode is invite_only | ✅ | ✅ | ✅ | |
 | Create a committee survey | ✅ | | | |
 
 #### Permission Inheritance

--- a/charts/lfx-platform/files/model.fga
+++ b/charts/lfx-platform/files/model.fga
@@ -58,6 +58,8 @@ type committee
     define writer: [user] or writer from project
     # @fgadoc:jtbd View committee settings
     define auditor: [user, team#member] or writer or auditor from project or meeting_coordinator from project
+    # @fgadoc:jtbd Invite a user to join a committee
+    define inviter: member or auditor
     # @fgadoc:jtbd View committee details & weekly brief
     # @fgadoc:jtbd View committee members, invites & applications
     # @fgadoc:jtbd View committee links, folders & documents

--- a/charts/lfx-platform/files/model.fga
+++ b/charts/lfx-platform/files/model.fga
@@ -58,7 +58,7 @@ type committee
     define writer: [user] or writer from project
     # @fgadoc:jtbd View committee settings
     define auditor: [user, team#member] or writer or auditor from project or meeting_coordinator from project
-    # @fgadoc:jtbd Invite a user to join a committee
+    # @fgadoc:jtbd Invite a user to join a committee when join mode is invite_only
     define inviter: member or auditor
     # @fgadoc:jtbd View committee details & weekly brief
     # @fgadoc:jtbd View committee members, invites & applications

--- a/charts/lfx-platform/templates/openfga/model.yaml
+++ b/charts/lfx-platform/templates/openfga/model.yaml
@@ -27,8 +27,8 @@ spec:
 */}}
     - version:
         major: 14
-        minor: 2
-        patch: 1
+        minor: 3
+        patch: 0
       authorizationModel: |
 {{ .Files.Get "files/model.fga" | indent 8 }}
 {{- end }}


### PR DESCRIPTION
## Summary

- Add `inviter` relation to the `committee` type in the OpenFGA model, defined as `member or auditor` — covering all committee members, auditors, and writers
- Re-render `PERMISSIONS.md` to include the new "Invite a user to join a committee" row in the Committee table (✅ for Writer, Auditor, Member)

## Ticket

[LFXV2-2690](https://linuxfoundation.atlassian.net/browse/LFXV2-2690)

🤖 Generated with [Claude Code](https://claude.ai/code)

[LFXV2-2690]: https://linuxfoundation.atlassian.net/browse/LFXV2-2690?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ