### PR TITLE
feat(chart): bump fga-sync to 0.3.7 for JetStream Phase 2

### DIFF
--- a/charts/lfx-platform/Chart.lock
+++ b/charts/lfx-platform/Chart.lock
@@ -7,7 +7,7 @@ dependencies:
   version: 0.2.62
 - name: heimdall
   repository: oci://ghcr.io/dadrus/heimdall/chart
-  version: 0.16.18
+  version: 0.16.19
 - name: nats
   repository: https://nats-io.github.io/k8s/helm/charts/
   version: 1.3.16
@@ -37,16 +37,16 @@ dependencies:
   version: v0.18.0
 - name: lfx-v2-query-service
   repository: oci://ghcr.io/linuxfoundation/lfx-v2-query-service/chart
-  version: 0.4.23
+  version: 0.4.24
 - name: lfx-v2-project-service
   repository: oci://ghcr.io/linuxfoundation/lfx-v2-project-service/chart
   version: 0.6.11
 - name: lfx-v2-fga-sync
   repository: oci://ghcr.io/linuxfoundation/lfx-v2-fga-sync/chart
-  version: 0.3.6
+  version: 0.3.7
 - name: lfx-v2-access-check
   repository: oci://ghcr.io/linuxfoundation/lfx-v2-access-check/chart
-  version: 0.3.5
+  version: 0.3.6
 - name: lfx-v2-indexer-service
   repository: oci://ghcr.io/linuxfoundation/lfx-v2-indexer-service/chart
   version: 0.4.25
@@ -85,9 +85,9 @@ dependencies:
   version: 0.8.0
 - name: lfx-v2-newsletter-service
   repository: oci://ghcr.io/linuxfoundation/lfx-v2-newsletter-service/chart
-  version: 0.1.25
+  version: 0.1.26
 - name: lfx-v2-persona-service
   repository: oci://ghcr.io/linuxfoundation/lfx-v2-persona-service/chart
   version: 0.0.9
-digest: sha256:3845cc5479a6120c5acc59828eac0a9c46949161b0a5bd4dbefdf8efc5f9ead6
-generated: "2026-07-31T15:51:24.506302+05:30"
+digest: sha256:a3c472bc6544185970441c742c04a459823ef3c50b0614f24ebec9d81636ab16
+generated: "2026-08-07T14:49:01.206016+05:30"


### PR DESCRIPTION
## Summary
- Bump `lfx-v2-fga-sync` chart lock from `0.3.6` to `0.3.7` so ArgoCD renders the widened `fga-sync-events` JetStream stream (adds `member_put`/`member_remove` subjects) and shared consumer required for LFXV2-2831 Phase 2.
- Incidental patch refreshes from `helm dependency update` for `heimdall` (`0.16.18` → `0.16.19`), `lfx-v2-query-service` (`0.4.23` → `0.4.24`), `lfx-v2-access-check` (`0.3.5` → `0.3.6`), and `lfx-v2-newsletter-service` (`0.1.25` → `0.1.26`) within existing Chart.yaml ranges. These can't be isolated out: `Chart.lock`'s digest covers the full resolved dependency set, not just the changed entry, so editing only the `fga-sync` line makes Helm reject the lock as out of sync with `Chart.yaml`.

## Context
`lfx-v2-fga-sync` [PR #59](https://github.com/linuxfoundation/lfx-v2-fga-sync/pull/59) merged and image/chart `v0.3.7` is published. This PR is the companion chart-pin bump needed for any environment's ArgoCD app to actually pick up the widened stream and shared consumer, the same way PR #158 did for Phase 1's `v0.3.6`.

Per the [fga-sync-jetstream-cutover runbook](https://github.com/linuxfoundation/lfx-v2-fga-sync/blob/main/docs/runbooks/fga-sync-jetstream-cutover.md), Phase 2 requires all four owning publisher services (committee-service, meeting-service, mailing-list-service, member-service) to be asynchronous-only for `member_put`/`member_remove` before this deploys to an environment. `member-service` PR #82 is merged; `committee-service` PR #164 is still open. Do not merge/sync this to an environment ahead of that.

## Test plan
- [ ] Merge and confirm which environment(s) this should sync to, given the open committee-service precondition above
- [ ] `kubectl get stream fga-sync-events -n lfx` → subjects include `member_put`/`member_remove`
- [ ] `kubectl get pods -n lfx -l app.kubernetes.io/name=lfx-v2-fga-sync` → new pod Running, old pod terminated
- [ ] Confirm no `JSConsumerFilterNotSubsetErr` or crash-loop in fga-sync logs

Jira: LFXV2-2831
Link: https://linuxfoundation.atlassian.net/browse/LFXV2-2831

Made with [Cursor](https://cursor.com)