### PR TITLE
docs(fga): fix incorrect campaign_manager cascade comment

### DIFF
--- a/charts/lfx-platform/files/model.fga
+++ b/charts/lfx-platform/files/model.fga
@@ -35,11 +35,14 @@ type project
     define executive_director: [user]
     define marketing_ops: [team#member] or marketing_ops from parent
     # marketing_auditor identifies a user with read access to marketing dashboards
-    # and campaigns for a project. Unlike campaign_manager, marketing_auditor
-    # cascades from parent projects — granting it at ROOT flows down to all
-    # sub-projects. The manager role does not cascade from parent; management
-    # rights are explicitly scoped to the project on which they are granted.
+    # and campaigns for a project. It cascades from parent projects — granting
+    # it at ROOT flows down to all sub-projects.
     define marketing_auditor: [team#member] or executive_director or marketing_ops or marketing_auditor from parent
+    # campaign_manager is intentionally the same population as marketing_ops
+    # (plus executive_director) — there is no separate campaign-manager grant
+    # path. It therefore also cascades from parent projects via marketing_ops:
+    # granting marketing_ops at ROOT makes that team campaign_manager on every
+    # descendant project.
     define campaign_manager: executive_director or marketing_ops
     # @fgadoc:jtbd View project details & meeting count
     # @fgadoc:jtbd View project links & folders


### PR DESCRIPTION
## Summary
- The comment on `marketing_auditor`/`campaign_manager` in `charts/lfx-platform/files/model.fga` claimed the manager role "does not cascade from parent" and is "explicitly scoped to the project on which they are granted." That's factually wrong: `campaign_manager` resolves to `executive_director or marketing_ops`, and `marketing_ops` itself cascades from parent (`marketing_ops from parent`). A single `project:ROOT#marketing_ops` tuple therefore grants `campaign_manager` on every descendant project.
- Per Misha Rautela's clarification on LFXV2-2236, this cascading is intentional — `campaign_manager` is meant to be exactly the `marketing_ops` population (plus `executive_director`); there is no separate Campaign Manager role.
- Comment-only fix — model semantics (types/relations/`define` logic) are unchanged, so no version bump per the policy documented in `charts/lfx-platform/templates/openfga/model.yaml`. Validated against repo history: prior comment/whitespace-only commits to this file (`2d9a5f3`, `2f63149`) also did not bump the version.
- Item G5 from the LFXV2-2231 gap-analysis.

LFXV2-3292

## Test plan
- [x] Reviewed diff — comment-only change, no `define`/type/relation modifications
- [x] Confirmed no version bump needed by precedent (prior comment-only commits didn't bump)
- [ ] CI passes