### PR TITLE
docs(openfga): add runbook and owner for manual global tuple provisioning

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -31,6 +31,7 @@
     "kubescape",
     "linuxfoundation",
     "lfx",
+    "LFXV",
     "livez",
     "mailpit",
     "mockdata",

--- a/docs/openfga.md
+++ b/docs/openfga.md
@@ -225,25 +225,37 @@ provision or change a global tuple through them.
    service/namespace).
 2. Write the tuple:
    ```bash
-   kubectl run --rm -it fga-cli --namespace <ns> --image=openfga/cli \
+   kubectl run --rm -it fga-cli --namespace <ns> --image=openfga/cli:v0.4.5 \
      --env="FGA_STORE_ID=$STORE_ID" \
      --env="FGA_API_URL=http://lfx-platform-openfga:8080" \
      --restart=Never -- tuple write \
-     --tuple "team:<teamID>#member:marketing_ops:project:ROOT"
+     "team:<teamID>#member" "marketing_ops" "project:ROOT"
    ```
-3. Verify it took effect with a `check` call against a relation that
-   actually depends on it (not `viewer` — see the note above about
-   `viewer` being public):
+3. Verify the tuple was written by reading it back:
    ```bash
-   kubectl run --rm -it fga-cli --namespace <ns> --image=openfga/cli \
+   kubectl run --rm -it fga-cli --namespace <ns> --image=openfga/cli:v0.4.5 \
      --env="FGA_STORE_ID=$STORE_ID" \
      --env="FGA_API_URL=http://lfx-platform-openfga:8080" \
-     --restart=Never -- check \
-     --tuple "user:<a-team-member>@example.com:marketing_auditor:project:<any-sub-project>"
+     --restart=Never -- tuple read \
+     --user "team:<teamID>#member" \
+     --relation "marketing_ops" \
+     --object "project:ROOT"
    ```
-   A successful check confirms both that the tuple was written and that it
-   cascades as expected.
-4. Record what you wrote in the table below, in the same PR/change that
+   If found, the tuple was successfully written.
+4. Verify cascade behavior with a `check` call against a relation that
+   actually depends on it (not `viewer` — see the note above about
+   `viewer` being public). This confirms the inheritance chain works as
+   expected but does not prove the ROOT tuple itself exists — use step 3
+   for that confirmation:
+   ```bash
+   kubectl run --rm -it fga-cli --namespace <ns> --image=openfga/cli:v0.4.5 \
+     --env="FGA_STORE_ID=$STORE_ID" \
+     --env="FGA_API_URL=http://lfx-platform-openfga:8080" \
+     --restart=Never -- query check \
+     "user:<a-team-member>@example.com" "marketing_auditor" "project:<any-sub-project>"
+   ```
+   A successful check confirms that the cascade behaves as expected.
+5. Record what you wrote in the table below, in the same PR/change that
    requested it, so this stays the source of truth for "what global tuples
    exist in which environment."
 
@@ -251,7 +263,7 @@ provision or change a global tuple through them.
 
 | Tuple | Environment(s) | Purpose | Provisioned by / date |
 | --- | --- | --- | --- |
-| `team:<marketing-ops-teamID>#member:marketing_ops:project:ROOT` | dev | Grants the LF Marketing Ops team `marketing_auditor`/`campaign_manager` on every project via cascade (LFXV2-2231) | _Not yet confirmed written to any environment as of 2026-08-17 — verify before relying on it; update this row once confirmed._ |
+| `team:<marketing-ops-teamID>#member:marketing_ops:project:ROOT` | (unconfirmed) | Grants the LF Marketing Ops team `marketing_auditor`/`campaign_manager` on every project via cascade (LFXV2-2231) | _Not yet confirmed written to any environment as of 2026-08-17 — verify before relying on it; update this row once confirmed._ |
 
 ## Advanced Topics
 

--- a/docs/openfga.md
+++ b/docs/openfga.md
@@ -196,6 +196,63 @@ Test authorization decisions:
 kubectl run --rm -it fga-cli --namespace lfx --image=openfga/cli --env="FGA_STORE_ID=$STORE_ID" --env="FGA_API_URL=http://lfx-platform-openfga:8080" --restart=Never -- check --tuple "user:john@example.com:writer:project:project1"
 ```
 
+## Provisioning Manually-Managed Global Tuples
+
+Some tuples are global/ROOT-scoped and have no owning service to write them
+automatically — they're seeded once by hand and rely on `... from parent`
+cascades in the model to apply everywhere. The Marketing Ops role added in
+LFXV2-2231 is the first example: `marketing_ops` is granted on
+`project:ROOT` and cascades to every project via
+`marketing_ops from parent` (which `marketing_auditor` and
+`campaign_manager` both resolve through).
+
+There is currently no admin UI for this (tracked separately as LFXV2-1760)
+and no service syncs these tuples from project-service or fga-sync
+(LFXV2-2233 was cancelled, LFXV2-2234 is not started) — manual `tuple write`
+via the OpenFGA CLI, as shown above, is the only path today. That makes two
+things easy to get wrong during an incident: nobody owns re-checking that a
+global tuple still exists, and there's no record to consult to rule out "was
+it ever written" as a cause.
+
+**Owner:** LF Staff Support (per the LFXV2-2231 epic's decision to defer
+manual tuple management there until LFXV2-1760 ships). Route requests to
+provision or change a global tuple through them.
+
+**Runbook:**
+
+1. Identify the target store for the environment in question (`STORE_ID`
+   lookup as shown above, against that environment's `lfx-platform-openfga`
+   service/namespace).
+2. Write the tuple:
+   ```bash
+   kubectl run --rm -it fga-cli --namespace <ns> --image=openfga/cli \
+     --env="FGA_STORE_ID=$STORE_ID" \
+     --env="FGA_API_URL=http://lfx-platform-openfga:8080" \
+     --restart=Never -- tuple write \
+     --tuple "team:<teamID>#member:marketing_ops:project:ROOT"
+   ```
+3. Verify it took effect with a `check` call against a relation that
+   actually depends on it (not `viewer` — see the note above about
+   `viewer` being public):
+   ```bash
+   kubectl run --rm -it fga-cli --namespace <ns> --image=openfga/cli \
+     --env="FGA_STORE_ID=$STORE_ID" \
+     --env="FGA_API_URL=http://lfx-platform-openfga:8080" \
+     --restart=Never -- check \
+     --tuple "user:<a-team-member>@example.com:marketing_auditor:project:<any-sub-project>"
+   ```
+   A successful check confirms both that the tuple was written and that it
+   cascades as expected.
+4. Record what you wrote in the table below, in the same PR/change that
+   requested it, so this stays the source of truth for "what global tuples
+   exist in which environment."
+
+**Currently provisioned manual tuples:**
+
+| Tuple | Environment(s) | Purpose | Provisioned by / date |
+| --- | --- | --- | --- |
+| `team:<marketing-ops-teamID>#member:marketing_ops:project:ROOT` | dev | Grants the LF Marketing Ops team `marketing_auditor`/`campaign_manager` on every project via cascade (LFXV2-2231) | _Not yet confirmed written to any environment as of 2026-08-17 — verify before relying on it; update this row once confirmed._ |
+
 ## Advanced Topics
 
 ### Events and Monitoring

--- a/docs/openfga.md
+++ b/docs/openfga.md
@@ -237,11 +237,12 @@ provision or change a global tuple through them.
      --env="FGA_STORE_ID=$STORE_ID" \
      --env="FGA_API_URL=http://lfx-platform-openfga:8080" \
      --restart=Never -- tuple read \
+     --consistency HIGHER_CONSISTENCY \
      --user "team:<teamID>#member" \
      --relation "marketing_ops" \
      --object "project:ROOT"
    ```
-   If found, the tuple was successfully written.
+   If found, the tuple was successfully written. This step uses `HIGHER_CONSISTENCY` to ensure fresh data, preventing false negatives from stale caches immediately after provisioning.
 4. Verify cascade behavior with a `check` call against a relation that
    actually depends on it (not `viewer` — see the note above about
    `viewer` being public). This confirms the inheritance chain works as
@@ -252,9 +253,10 @@ provision or change a global tuple through them.
      --env="FGA_STORE_ID=$STORE_ID" \
      --env="FGA_API_URL=http://lfx-platform-openfga:8080" \
      --restart=Never -- query check \
+     --consistency HIGHER_CONSISTENCY \
      "user:<a-team-member>@example.com" "marketing_auditor" "project:<any-sub-project>"
    ```
-   A successful check confirms that the cascade behaves as expected.
+   A successful check (returned `"allowed": true`) confirms that the cascade behaves as expected. Note that the CLI always exits with code 0 even when `allowed: false`, so you must inspect the response body to verify success.
 5. Record what you wrote in the table below, in the same PR/change that
    requested it, so this stays the source of truth for "what global tuples
    exist in which environment."


### PR DESCRIPTION
## Summary
- Global/ROOT-scoped OpenFGA tuples (e.g. the Marketing Ops team grant, `project:ROOT#marketing_ops@team:<teamID>#member` from LFXV2-2231) have no owning service or admin UI (LFXV2-1760 not delivered, LFXV2-2233 cancelled, LFXV2-2234 not started) — manual `tuple write` is the only provisioning path today, and it was undocumented, unowned, and unrecorded.
- Adds a "Provisioning Manually-Managed Global Tuples" section to `docs/openfga.md`: names LF Staff Support as owner (per the LFXV2-2231 epic's existing decision), documents write + verify steps using the existing fga-cli pattern in this doc, and adds a tracked table of currently-provisioned manual tuples per environment.
- This closes a gap directly relevant to the 2026-07-16 LFXV2-2236 production incident post-mortem, where "was the ROOT tuple ever actually written" could not be ruled out because there was no record to check.
- Item G9 from the LFXV2-2231 gap-analysis.

LFXV2-3293

## Test plan
- [x] Reviewed diff — doc-only addition, no changes to model.fga or model.yaml
- [ ] CI passes