### PR TITLE
feat(heimdall): add project slug-to-uid resolver contextualizer (LFXV2-3324)

### DIFF
--- a/charts/lfx-platform/values.yaml
+++ b/charts/lfx-platform/values.yaml
@@ -298,11 +298,22 @@ heimdall:
       # gap G7). continue_pipeline_on_error is false: a failed resolution
       # must deny the request, not silently authorize against an
       # unresolved/empty object.
+      #
+      # The endpoint MUST be the shared Gateway hostname, not project-service's
+      # ClusterIP — same reason oidc_contextualizer above targets
+      # auth.k8s.orb.local rather than Authelia's ClusterIP. A direct ClusterIP
+      # call bypasses project-service's own Heimdall RuleSet entirely, so the
+      # forwarded raw Authorization header (a caller's OAuth token) would hit
+      # the app directly; project-service's JWT check only accepts a
+      # Heimdall-minted JWT (validated against Heimdall's own JWKS), which is
+      # exactly what routing through the Gateway produces via project-service's
+      # oidc authenticator + create_jwt finalizer. Do not change this back to
+      # the ClusterIP address.
       - id: project_slug_resolver_contextualizer
         type: generic
         config:
           endpoint:
-            url: http://lfx-v2-project-service:8080/projects/slug-to-uid/{{ .Values.slug }}
+            url: http://lfx-api.k8s.orb.local/projects/slug-to-uid/{{ .Values.slug }}
             method: GET
           forward_headers:
             - Authorization

--- a/charts/lfx-platform/values.yaml
+++ b/charts/lfx-platform/values.yaml
@@ -290,6 +290,23 @@ heimdall:
           # Continuing on error is needed if this contextualizer is used in any
           # rulesets that support anonymous access.
           continue_pipeline_on_error: true
+      # Resolves a project slug (from a RuleSet-supplied "slug" value) to its
+      # canonical project UID via project-service's own NATS-backed lookup,
+      # exposed over HTTP for this purpose. Needed because some services
+      # (e.g. lfx-v2-campaign-service) receive project slugs on the wire,
+      # while OpenFGA tuples are keyed on project UID — LFXV2-3324 (LFXV2-2231
+      # gap G7). continue_pipeline_on_error is false: a failed resolution
+      # must deny the request, not silently authorize against an
+      # unresolved/empty object.
+      - id: project_slug_resolver_contextualizer
+        type: generic
+        config:
+          endpoint:
+            url: http://lfx-v2-project-service:8080/projects/slug-to-uid/{{ .Values.slug }}
+            method: GET
+          forward_headers:
+            - Authorization
+          continue_pipeline_on_error: false
     authorizers:
       - id: allow_all
         type: allow


### PR DESCRIPTION
## Purpose

Step 2 of a 3-repo fix for **LFXV2-2231** gap G7 (tracked in **LFXV2-3324**): some services (e.g. `lfx-v2-campaign-service`) receive project **slugs** on the wire, but OpenFGA tuples for `campaign_manager`/`marketing_ops` are keyed on project **UID**, so an FGA object check built directly from the URL-captured slug can never match. Left unresolved, this is a total lockout of the affected API surface once that service's authz code is promoted to staging/prod.

Fix sequence:
1. `lfx-v2-project-service` — exposes `GET /projects/slug-to-uid/{slug}` over HTTP, wrapping its existing canonical NATS-based lookup. ([PR #100](https://github.com/linuxfoundation/lfx-v2-project-service/pull/100))
2. **(this PR)** `lfx-v2-helm` — adds a new Heimdall `generic` contextualizer that calls that endpoint to resolve slug→UID before an FGA check runs.
3. `lfx-v2-campaign-service` — updates its RuleSet to check the resolved UID (`.Outputs.project_slug_resolver_contextualizer.uid`) instead of the raw URL-captured slug. Not part of this PR.

## Summary

Adds `project_slug_resolver_contextualizer` to `charts/lfx-platform/values.yaml`, modeled on the existing `oidc_contextualizer` pattern:

- `type: generic`, calls `GET http://lfx-v2-project-service:8080/projects/slug-to-uid/{{ .Values.slug }}` (in-cluster service DNS, works across all envs — same pattern as the `openfga_check` authorizer's endpoint, not the local-dev-only `auth.k8s.orb.local` host used by `oidc_contextualizer`)
- Forwards the `Authorization` header (the endpoint requires JWTAuth)
- `continue_pipeline_on_error: false` — a failed slug resolution must deny the request rather than let a downstream FGA check proceed against an unresolved/empty object

A consuming RuleSet (step 3) supplies the slug via `config.values.slug` templated from its own URL capture, same pattern as `openfga_check`'s per-rule `relation`/`object` overrides.

## Validation

- `helm dependency update charts/lfx-platform` — succeeded (Chart.lock diff reverted; unrelated to this change)
- `helm lint charts/lfx-platform` — 0 failures
- `helm template lfx-platform charts/lfx-platform` — confirmed the new contextualizer renders correctly into the Heimdall mechanisms config

## Related Issues

Tracked by **LFXV2-3324** (subtask of epic **LFXV2-2231**), gap G7.