### PR TITLE
ci: bump MegaLinter workflow checkout action to v6.0.3

### DIFF
--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       # Git Checkout
       - name: Checkout Code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
           fetch-depth: 0
           persist-credentials: false


### PR DESCRIPTION
## Summary

Minor MegaLinter workflow standardization per LFXV2-3338.

- Bump `actions/checkout` pin from v4.2.2 to v6.0.3, matching other LFX repos.

Everything else in this repo's MegaLinter setup is already exemplary and was left untouched (already on v9.6.0, `ACTION_ZIZMOR_UNSECURED_ENV_VARIABLES` already configured, and the `slsa-github-generator` tag-pin + documented zizmor ignore in `release.yaml` is the reference pattern other repos in this rollout are being aligned to).

## Jira

LFXV2-3338

🤖 Generated with [GitHub Copilot](https://github.com/features/copilot) (via OpenCode)